### PR TITLE
Give email address in message when throwing exception for bad email address

### DIFF
--- a/src/LooplineSystems/CloseIoApiWrapper/Model/Email.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Model/Email.php
@@ -60,7 +60,7 @@ class Email implements \JsonSerializable
     public function setEmail($email)
     {
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            throw new InvalidParamException('Invalid email format');
+            throw new InvalidParamException('Invalid email format: "' . $email . '"');
         } else {
             $this->email = $email;
         }


### PR DESCRIPTION
Somehow we had a contact in Close that had an email address stored with a leading space. LeadApi->getLead() tried to populate a Lead object with the data from Close, but threw an InvalidParamException after it failed the email validity check.