### PR TITLE
Remove organization from invalid properties on post lead

### DIFF
--- a/src/LooplineSystems/CloseIoApiWrapper/Api/LeadApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/LeadApi.php
@@ -160,7 +160,7 @@ class LeadApi extends AbstractApi
      */
     public function validateLeadForPost(Lead $lead)
     {
-        $invalidProperties = ['id', 'organization', 'tasks', 'opportunities'];
+        $invalidProperties = ['id', 'tasks', 'opportunities'];
         foreach ($invalidProperties as $invalidProperty) {
             $getter = 'get' . ucfirst($invalidProperty);
             if ($lead->$getter()) {


### PR DESCRIPTION
@mickadoo Is there a reason for excluding exactly this field? And would it make sense to remove validateLeadForPost completely and to rely on errors sent from closeio?