### PR TITLE
Send custom fields on Lead object in format custom.FIELD_NAME/ID

### DIFF
--- a/src/LooplineSystems/CloseIoApiWrapper/Model/Lead.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Model/Lead.php
@@ -259,7 +259,7 @@ class Lead implements \JsonSerializable
     }
 
     /**
-     * Set custom fields. They must alraedy exist in your Close instance.
+     * Set custom fields. They must already exist in your Close.io instance.
      * Note that if you set the fields using the unique custom field IDs rather than names (accessible through CustomFieldApi),
      * it's possible to set null values. Otherwise, setting null will give an error and it's not possible to unset values.
      *

--- a/src/LooplineSystems/CloseIoApiWrapper/Model/Lead.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Model/Lead.php
@@ -259,6 +259,10 @@ class Lead implements \JsonSerializable
     }
 
     /**
+     * Set custom fields. They must alraedy exist in your Close instance.
+     * Note that if you set the fields using the unique custom field IDs rather than names (accessible through CustomFieldApi),
+     * it's possible to set null values. Otherwise, setting null will give an error and it's not possible to unset values.
+     *
      * @param $custom
      * @return $this
      */


### PR DESCRIPTION
Previously, custom fields on leads were sent as a dictionary called 'custom'.

According to the Close documentation here: https://developer.close.io/#leads , this format is deprecated and will be removed (although when you request a lead from the API, it's still given in this format!)

Additionally, when sending using this format, it's not possible to unset values.

This PR converts the 'custom' array into multiple properties called custom.FIELD_NAME or custom.FIELD_ID (whichever you use) just before sending to the API. Note that it's necessary to use the field IDs if you want to be able to unset values (by setting value as null)