### PR TITLE
Fix for PHP 7.1 behavior when calling variable functions

### DIFF
--- a/src/LooplineSystems/CloseIoApiWrapper/Library/ObjectHydrateHelperTrait.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Library/ObjectHydrateHelperTrait.php
@@ -40,7 +40,7 @@ trait ObjectHydrateHelperTrait
                 } else {
                     // check if setter method exists that doesn't match inflected filter format
                     if (in_array($setter, array_keys($method_mapper))) {
-                        $this->$method_mapper[$setter]($value);
+                        $this->{$method_mapper[$setter]}($value);
                     } else {
                         // value is not set - Entities should be extended if needed
                     }

--- a/tests/LooplineSystems/CloseIoApiWrapper/Library/Fake/ObjectHydrateHelperDemo.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Library/Fake/ObjectHydrateHelperDemo.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Close.io Api Wrapper - LLS Internet GmbH - Loopline Systems
+ *
+ * @link      https://github.com/loopline-systems/closeio-api-wrapper for the canonical source repository
+ * @copyright Copyright (c) 2014 LLS Internet GmbH - Loopline Systems (http://www.loopline-systems.com)
+ * @license   https://github.com/loopline-systems/closeio-api-wrapper/blob/master/LICENSE (MIT Licence)
+ */
+
+namespace Tests\LooplineSystems\CloseIoApiWrapper\Library\Fake;
+
+use LooplineSystems\CloseIoApiWrapper\CloseIoRequest;
+use LooplineSystems\CloseIoApiWrapper\CloseIoApiWrapper;
+use LooplineSystems\CloseIoApiWrapper\CloseIoConfig;
+use LooplineSystems\CloseIoApiWrapper\Library\ObjectHydrateHelperTrait;
+
+class ObjectHydrateHelperDemo
+{
+    use ObjectHydrateHelperTrait;
+
+    private $first;
+
+    private $second;
+
+    /**
+     * @return mixed
+     */
+    public function getFirst()
+    {
+        return $this->first;
+    }
+
+    /**
+     * @param mixed $first
+     */
+    public function setFirst($first)
+    {
+        $this->first = $first;
+    }
+    /**
+     * @return mixed
+     */
+    public function getSecond()
+    {
+        return $this->second;
+    }
+
+    /**
+     * @param mixed $second
+     */
+    public function setSecond($second)
+    {
+        $this->second = $second;
+    }
+}

--- a/tests/LooplineSystems/CloseIoApiWrapper/Library/ObjectHydrateHelperTraitTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Library/ObjectHydrateHelperTraitTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Close.io Api Wrapper - LLS Internet GmbH - Loopline Systems
+ *
+ * @link      https://github.com/loopline-systems/closeio-api-wrapper for the canonical source repository
+ * @copyright Copyright (c) 2014 LLS Internet GmbH - Loopline Systems (http://www.loopline-systems.com)
+ * @license   https://github.com/loopline-systems/closeio-api-wrapper/blob/master/LICENSE (MIT Licence)
+ */
+
+namespace Tests\LooplineSystems\CloseIoApiWrapper\Library;
+
+use Tests\LooplineSystems\CloseIoApiWrapper\Library\Fake\ObjectHydrateHelperDemo;
+
+class ObjectHydrateHelperTraitTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ObjectHydrateHelperDemo
+     */
+    private $testObject;
+
+    public function setUp()
+    {
+        $this->testObject = new ObjectHydrateHelperDemo();
+    }
+
+    public function testHydrateWithoutData()
+    {
+        $data = [];
+
+        $this->testObject->hydrate($data);
+
+        $this->assertNull($this->testObject->getFirst());
+        $this->assertNull($this->testObject->getSecond());
+    }
+
+    public function testHydratePartialData()
+    {
+        $data = [
+            'first' => 10,
+        ];
+
+        $this->testObject->hydrate($data);
+
+        $this->assertEquals(10, $this->testObject->getFirst());
+        $this->assertNull($this->testObject->getSecond());
+    }
+
+    public function testDoNotHydrateFalsyData()
+    {
+        $this->testObject->hydrate(['first' => false]);
+        $this->assertNull($this->testObject->getFirst());
+
+        $this->testObject->hydrate(['first' => 0]);
+        $this->assertNull($this->testObject->getFirst());
+
+        $this->testObject->hydrate(['first' => null]);
+        $this->assertNull($this->testObject->getFirst());
+    }
+
+    public function testHydrateAllData()
+    {
+        $data = [
+            'first' => 10,
+            'second' => 'test',
+        ];
+
+        $this->testObject->hydrate($data);
+
+        $this->assertEquals(10, $this->testObject->getFirst());
+        $this->assertEquals('test', $this->testObject->getSecond());
+    }
+
+    public function testNonHydrateNonExistingData()
+    {
+        $data = [
+            'third' => 10,
+        ];
+
+        $this->testObject->hydrate($data);
+
+        $this->assertNull($this->testObject->getFirst());
+        $this->assertNull($this->testObject->getSecond());
+    }
+
+    public function testHydrateWithCustomMappingData()
+    {
+        $data = [
+            'third' => 10,
+        ];
+
+        $this->testObject->hydrate($data, [], ['setThird' => 'setFirst']);
+
+        $this->assertEquals(10, $this->testObject->getFirst());
+        $this->assertNull($this->testObject->getSecond());
+    }
+}


### PR DESCRIPTION
Fixes these notices and subsequent failure when initializing `new Task()`

```
PHP Notice:  Array to string conversion in /srv/www/inc/libraries/vendor/loopline-systems/closeio-api-wrapper/src/LooplineSystems/CloseIoApiWrapper/Library/ObjectHydrateHelperTrait.php on line 45

PHP Notice:  Undefined property: LooplineSystems\CloseIoApiWrapper\Model\Task::$Array in /srv/www/inc/libraries/vendor/loopline-systems/closeio-api-wrapper/src/LooplineSystems/CloseIoApiWrapper/Library/ObjectHydrateHelperTrait.php on line 45```