### PR TITLE
Fix command in .travis.yml to install and invoke PHPSTAN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_script:
 script:
     - mkdir -p build/logs
     - vendor/bin/phpunit
-    - if [ "$TRAVIS_PHP_VERSION" != "5.6" && "$dependencies" = "highest" ]; then composer require --dev phpstan/phpstan; fi;
-    - if [ "$TRAVIS_PHP_VERSION" != "5.6" && "$dependencies" = "highest" ]; then php vendor/bin/phpstan analyze --level=4 src tests; fi;
+    - if [ "$TRAVIS_PHP_VERSION" != "5.6" ] && [ "$dependencies" = "highest" ]; then composer require --dev phpstan/phpstan; fi;
+    - if [ "$TRAVIS_PHP_VERSION" != "5.6" ] && [ "$dependencies" = "highest" ]; then php vendor/bin/phpstan analyze --level=4 src tests; fi;
 
 after_script:
     - php vendor/bin/php-coveralls -v


### PR DESCRIPTION
@mavimo there's an error that doesn't let travis to execute correctly `phpstan`.
I've fixed the syntax of the command