### PR TITLE
refs #48 #49: update dependencies to last version supported on php 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_script:
 script:
     - mkdir -p build/logs
     - vendor/bin/phpunit
-    - if [ "$dependencies" = "highest" ]; then composer require --dev phpstan/phpstan; fi;
     - if [ "$dependencies" = "highest" ]; then php vendor/bin/phpstan analyze --level=4 src tests; fi;
 
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,12 @@
     "require": {
         "php": ">=7.1.0",
         "ext-curl": "*",
-        "doctrine/inflector": "^1.0"
+        "doctrine/inflector": "^1.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.10",
-        "php-coveralls/php-coveralls": "^2.0"
+        "phpunit/phpunit": "^7.3.1",
+        "php-coveralls/php-coveralls": "^2.0",
+        "phpstan/phpstan": "^0.10.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/LooplineSystems/CloseIoApiWrapper/Library/ObjectHydrateHelperTrait.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Library/ObjectHydrateHelperTrait.php
@@ -11,7 +11,6 @@ namespace LooplineSystems\CloseIoApiWrapper\Library;
 
 use Doctrine\Common\Inflector\Inflector;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidParamException;
-use Zend\Filter\Word\UnderscoreToCamelCase;
 
 trait ObjectHydrateHelperTrait
 {

--- a/tests/LooplineSystems/CloseIoApiWrapper/Api/ActivityApiTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Api/ActivityApiTest.php
@@ -16,7 +16,7 @@ use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
 use LooplineSystems\CloseIoApiWrapper\Library\Curl\Curl;
 use LooplineSystems\CloseIoApiWrapper\Model\SmsActivity;
 
-class ActivityApiTest extends \PHPUnit_Framework_TestCase
+class ActivityApiTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @description tests updating a sms activity using mock curl object

--- a/tests/LooplineSystems/CloseIoApiWrapper/Api/ConfigTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Api/ConfigTest.php
@@ -12,7 +12,7 @@ namespace Tests\LooplineSystems\CloseIoApiWrapper\Api;
 use LooplineSystems\CloseIoApiWrapper\CloseIoConfig;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidParamException;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @param string $url

--- a/tests/LooplineSystems/CloseIoApiWrapper/Api/CustomFieldApiTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Api/CustomFieldApiTest.php
@@ -15,7 +15,7 @@ use LooplineSystems\CloseIoApiWrapper\CloseIoConfig;
 use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
 use LooplineSystems\CloseIoApiWrapper\Model\CustomField;
 
-class CustomFieldApiTest extends \PHPUnit_Framework_TestCase
+class CustomFieldApiTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider customFieldArrayProvider

--- a/tests/LooplineSystems/CloseIoApiWrapper/Api/LeadsApiTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Api/LeadsApiTest.php
@@ -14,7 +14,7 @@ use LooplineSystems\CloseIoApiWrapper\CloseIoConfig;
 use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
 use LooplineSystems\CloseIoApiWrapper\Model\Lead;
 
-class LeadsApiTest extends \PHPUnit_Framework_TestCase
+class LeadsApiTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @param Lead $lead

--- a/tests/LooplineSystems/CloseIoApiWrapper/CloseIoApiWrapperTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/CloseIoApiWrapperTest.php
@@ -21,7 +21,7 @@ use LooplineSystems\CloseIoApiWrapper\Api\UserApi;
 use LooplineSystems\CloseIoApiWrapper\CloseIoApiWrapper;
 use LooplineSystems\CloseIoApiWrapper\CloseIoConfig;
 
-class CloseIoApiWrapperTest extends \PHPUnit_Framework_TestCase
+class CloseIoApiWrapperTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreateCloseIoWrapper()
     {

--- a/tests/LooplineSystems/CloseIoApiWrapper/CloseIoConfigTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/CloseIoConfigTest.php
@@ -12,7 +12,7 @@ namespace Tests\LooplineSystems\CloseIoApiWrapper;
 use LooplineSystems\CloseIoApiWrapper\CloseIoConfig;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidParamException;
 
-class CloseIoConfigTest extends \PHPUnit_Framework_TestCase
+class CloseIoConfigTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreateCloseIoConfigHaveValidUrlByDefault()
     {

--- a/tests/LooplineSystems/CloseIoApiWrapper/CloseIoRequestTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/CloseIoRequestTest.php
@@ -14,7 +14,7 @@ use LooplineSystems\CloseIoApiWrapper\CloseIoConfig;
 use LooplineSystems\CloseIoApiWrapper\Library\Api\ApiHandler;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidParamException;
 
-class CloseIoRequestTest extends \PHPUnit_Framework_TestCase
+class CloseIoRequestTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/LooplineSystems/CloseIoApiWrapper/CloseIoResponseTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/CloseIoResponseTest.php
@@ -11,7 +11,7 @@ namespace Tests\LooplineSystems\CloseIoApiWrapper;
 
 use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
 
-class CloseIoResponseTest extends \PHPUnit_Framework_TestCase
+class CloseIoResponseTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @param string $jsonResponse

--- a/tests/LooplineSystems/CloseIoApiWrapper/Library/Curl/CurlTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Library/Curl/CurlTest.php
@@ -15,7 +15,7 @@ use LooplineSystems\CloseIoApiWrapper\CloseIoConfig;
 use LooplineSystems\CloseIoApiWrapper\Library\Curl\Curl;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\BadApiRequestException;
 
-class CurlTest extends \PHPUnit_Framework_TestCase
+class CurlTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetResponse()
     {

--- a/tests/LooplineSystems/CloseIoApiWrapper/Library/Exception/ExceptionsTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Library/Exception/ExceptionsTest.php
@@ -11,7 +11,7 @@ namespace Tests\LooplineSystems\CloseIoApiWrapper\Library\Exception;
 
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\JsonDecodingException;
 
-class ExceptionsTest extends \PHPUnit_Framework_TestCase
+class ExceptionsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @param string $data

--- a/tests/LooplineSystems/CloseIoApiWrapper/Library/ObjectHydrateHelperTraitTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Library/ObjectHydrateHelperTraitTest.php
@@ -11,7 +11,7 @@ namespace Tests\LooplineSystems\CloseIoApiWrapper\Library;
 
 use Tests\LooplineSystems\CloseIoApiWrapper\Library\Fake\ObjectHydrateHelperDemo;
 
-class ObjectHydrateHelperTraitTest extends \PHPUnit_Framework_TestCase
+class ObjectHydrateHelperTraitTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var ObjectHydrateHelperDemo

--- a/tests/LooplineSystems/CloseIoApiWrapper/Model/EmailTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Model/EmailTest.php
@@ -12,7 +12,7 @@ namespace Tests\LooplineSystems\CloseIoApiWrapper\Model;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidParamException;
 use LooplineSystems\CloseIoApiWrapper\Model\Email;
 
-class EmailTest extends \PHPUnit_Framework_TestCase
+class EmailTest extends \PHPUnit\Framework\TestCase
 {
     public function testInstantiateWithoutData()
     {

--- a/tests/LooplineSystems/CloseIoApiWrapper/Model/PhoneTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Model/PhoneTest.php
@@ -11,7 +11,7 @@ namespace Tests\LooplineSystems\CloseIoApiWrapper\Model;
 
 use LooplineSystems\CloseIoApiWrapper\Model\Phone;
 
-class PhoneTest extends \PHPUnit_Framework_TestCase
+class PhoneTest extends \PHPUnit\Framework\TestCase
 {
     public function testInstantiateWithoutData()
     {

--- a/tests/LooplineSystems/CloseIoApiWrapper/Model/UrlTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Model/UrlTest.php
@@ -11,7 +11,7 @@ namespace Tests\LooplineSystems\CloseIoApiWrapper\Model;
 
 use LooplineSystems\CloseIoApiWrapper\Model\Url;
 
-class UrlTest extends \PHPUnit_Framework_TestCase
+class UrlTest extends \PHPUnit\Framework\TestCase
 {
     public function testInstantiateWithoutData()
     {


### PR DESCRIPTION
Closes #48 #49

 - update dependencies to last version supported on php 7
 - update dev-dependencies to last version supported on php 7
 - Include phpstan as dev-dependency
 - Migrate phpunit test to namespaced classes