### PR TITLE
Standardize and refactor the API handlers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "require": {
         "php": ">=7.1.0",
         "ext-curl": "*",
+        "ext-json": "*",
         "doctrine/inflector": "^1.3.0"
     },
     "require-dev": {

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/ActivityApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/ActivityApi.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 /**
  * Close.io Api Wrapper - LLS Internet GmbH - Loopline Systems
  *
@@ -11,10 +14,7 @@ namespace LooplineSystems\CloseIoApiWrapper\Api;
 
 use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
 use LooplineSystems\CloseIoApiWrapper\Library\Api\AbstractApi;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\BadApiRequestException;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidParamException;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\ResourceNotFoundException;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\UrlNotSetException;
 use LooplineSystems\CloseIoApiWrapper\Model\Activity;
 use LooplineSystems\CloseIoApiWrapper\Model\CallActivity;
 use LooplineSystems\CloseIoApiWrapper\Model\EmailActivity;
@@ -23,6 +23,11 @@ use LooplineSystems\CloseIoApiWrapper\Model\SmsActivity;
 
 class ActivityApi extends AbstractApi
 {
+    /**
+     * The maximum number of items that are requested by default
+     */
+    private const MAX_ITEMS_PER_REQUEST = 50;
+
     const NAME = 'ActivityApi';
 
     /**
@@ -31,271 +36,566 @@ class ActivityApi extends AbstractApi
     protected function initUrls()
     {
         $this->urls = [
+            'get-activities' => '/activity/',
+            'get-call' => '/activity/call/[:id]/',
+            'delete-call' => '/activity/call/[:id]/',
             'add-note' => '/activity/note/',
             'get-notes' => '/activity/note/',
+            'delete-note' => '/activity/note/[:id]/',
+            'get-note' => '/activity/note/[:id]/',
+            'update-note' => '/activity/note/[:id]/',
             'add-call' => '/activity/call/',
             'get-calls' => '/activity/call/',
             'add-email' => '/activity/email/',
             'get-emails' => '/activity/email/',
+            'get-email' => '/activity/email/[:id]/',
+            'update-email' => '/activity/email/[:id]/',
+            'delete-email' => '/activity/email/[:id]/',
             'list-sms' => '/activity/sms/',
             'add-sms' => '/activity/sms/',
-            'delete-sms' => '/activity/sms/[:id]',
-            'get-sms' => '/activity/sms/[:id]',
+            'delete-sms' => '/activity/sms/[:id]/',
+            'get-sms' => '/activity/sms/[:id]/',
+            'update-sms' => '/activity/sms/[:id]/',
         ];
     }
+
     /**
-     * @param \LooplineSystems\CloseIoApiWrapper\Library\Curl\Curl $curl
+     * Gets up to the specified number of activities that match the given
+     * criteria.
+     *
+     * @param int      $offset  The offset from which start getting the items
+     * @param int      $limit   The maximum number of items to get
+     * @param array    $filters A set of criteria to filter the items by
+     * @param string[] $fields  The subset of fields to get (defaults to all)
+     *
+     * @return Activity[]
      */
-    public function setCurl($curl)
+    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
     {
-        $this->curl = $curl;
+        /** @var Activity[] $activities */
+        $activities = [];
+        $result = $this->triggerGet(
+            $this->prepareRequest('get-activities', null, [], array_merge($filters, [
+                '_skip' => $offset,
+                '_limit' => $limit,
+                '_fields' => $fields,
+            ]))
+        );
+
+        if (200 === $result->getReturnCode()) {
+            $responseData = $result->getData();
+
+            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $activity) {
+                $activities[] = new Activity($activity);
+            }
+        }
+
+        return $activities;
     }
 
     /**
-     * @param NoteActivity $activity
+     * Gets up to the specified number of call activities that match the given
+     * criteria.
      *
-     * @return Activity
+     * @param int      $offset  The offset from which start getting the items
+     * @param int      $limit   The maximum number of items to get
+     * @param array    $filters A set of criteria to filter the items by
+     * @param string[] $fields  The subset of fields to get (defaults to all)
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @return CallActivity[]
      */
-    public function addNote(NoteActivity $activity)
+    public function getAllCalls(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
     {
-        $activity = json_encode($activity);
-        $apiRequest = $this->prepareRequest('add-note', $activity);
+        /** @var CallActivity[] $activities */
+        $activities = [];
+        $result = $this->triggerGet(
+            $this->prepareRequest('get-calls', null, [], array_merge($filters, [
+                '_skip' => $offset,
+                '_limit' => $limit,
+                '_fields' => $fields,
+            ]))
+        );
 
-        $result = $this->triggerPost($apiRequest);
+        if (200 === $result->getReturnCode()) {
+            $responseData = $result->getData();
 
-        return new NoteActivity($result->getData());
+            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $activity) {
+                $activities[] = new CallActivity($activity);
+            }
+        }
+
+        return $activities;
     }
 
     /**
-     * @param CallActivity $call
+     * Gets the information about the call activity that matches the given ID.
+     *
+     * @param string $id The ID of the activity
      *
      * @return CallActivity
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @throws ResourceNotFoundException If a call activity with the given ID
+     *                                   doesn't exists
      */
-    public function addCall(CallActivity $call)
+    public function getCall(string $id): CallActivity
     {
-        $call = json_encode($call);
-        $apiRequest = $this->prepareRequest('add-call', $call);
-
-        $result = $this->triggerPost($apiRequest);
+        $result = $this->triggerGet($this->prepareRequest('get-call', null, ['id' => $id]));
 
         return new CallActivity($result->getData());
     }
 
     /**
-     * @param EmailActivity $email
+     * Creates a new call activity using the given information.
+     *
+     * @param CallActivity $callActivity The information of the call activity
+     *                                   to create
+     *
+     * @return CallActivity
+     */
+    public function createCall(CallActivity $callActivity): CallActivity
+    {
+        $apiRequest = $this->prepareRequest('add-call', json_encode($callActivity));
+
+        return new CallActivity($this->triggerPost($apiRequest)->getData());
+    }
+
+    /**
+     * Deletes the given call activity.
+     *
+     * @param string $callActivityId The ID of the call activity to delete
+     *
+     * @throws ResourceNotFoundException If a call activity with the given ID
+     *                                   doesn't exists
+     */
+    public function deleteCall(string $callActivityId): void
+    {
+        $this->triggerDelete($this->prepareRequest('delete-call', null, ['id' => $callActivityId]));
+    }
+
+    /**
+     * Gets up to the specified number of email activities that match the given
+     * criteria.
+     *
+     * @param int      $offset  The offset from which start getting the items
+     * @param int      $limit   The maximum number of items to get
+     * @param array    $filters A set of criteria to filter the items by
+     * @param string[] $fields  The subset of fields to get (defaults to all)
+     *
+     * @return EmailActivity[]
+     */
+    public function getAllEmails(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    {
+        /** @var EmailActivity[] $activities */
+        $activities = [];
+        $result = $this->triggerGet(
+            $this->prepareRequest('get-emails', null, [], array_merge($filters, [
+                '_skip' => $offset,
+                '_limit' => $limit,
+                '_fields' => $fields,
+            ]))
+        );
+
+        if (200 === $result->getReturnCode()) {
+            $responseData = $result->getData();
+
+            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $activity) {
+                $activities[] = new CallActivity($activity);
+            }
+        }
+
+        return $activities;
+    }
+
+    /**
+     * Gets the information about the email activity that matches the given ID.
+     *
+     * @param string $id The ID of the activity
      *
      * @return EmailActivity
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @throws ResourceNotFoundException If an email activity with the given ID
+     *                                   doesn't exists
      */
-    public function addEmail(EmailActivity $email)
+    public function getEmail(string $id): EmailActivity
     {
-        $email = json_encode($email);
-        $apiRequest = $this->prepareRequest('add-email', $email);
-
-        $result = $this->triggerPost($apiRequest);
+        $result = $this->triggerGet($this->prepareRequest('get-email', null, ['id' => $id]));
 
         return new EmailActivity($result->getData());
     }
 
     /**
-     * @param array $filters
+     * Creates a new email activity using the given information.
+     *
+     * @param EmailActivity $activity The information of the email activity to
+     *                                create
+     *
+     * @return EmailActivity
+     */
+    public function createEmail(EmailActivity $activity): EmailActivity
+    {
+        $apiRequest = $this->prepareRequest('add-email', json_encode($activity));
+
+        return new EmailActivity($this->triggerPost($apiRequest)->getData());
+    }
+
+    /**
+     * Updates the given email activity.
+     *
+     * @param EmailActivity $activity The activity to update
+     *
+     * @return EmailActivity
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID doesn't exists
+     */
+    public function updateEmail(EmailActivity $activity): EmailActivity
+    {
+        $id = $activity->getId();
+
+        $activity->setId(null);
+
+        $response = $this->triggerPut($this->prepareRequest('update-email', json_encode($activity), ['id' => $id]));
+
+        return new EmailActivity($response->getData());
+    }
+
+    /**
+     * Deletes the given email activity.
+     *
+     * @param string $activityId The ID of the email activity to delete
+     *
+     * @throws ResourceNotFoundException If a call activity with the given ID
+     *                                   doesn't exists
+     */
+    public function deleteEmail(string $activityId): void
+    {
+        $this->triggerDelete($this->prepareRequest('delete-email', null, ['id' => $activityId]));
+    }
+
+    /**
+     * Gets up to the specified number of note activities that match the given
+     * criteria.
+     *
+     * @param int      $offset  The offset from which start getting the items
+     * @param int      $limit   The maximum number of items to get
+     * @param array    $filters A set of criteria to filter the items by
+     * @param string[] $fields  The subset of fields to get (defaults to all)
+     *
+     * @return NoteActivity[]
+     */
+    public function getAllNotes(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    {
+        /** @var NoteActivity[] $activities */
+        $activities = [];
+        $result = $this->triggerGet(
+            $this->prepareRequest('get-notes', null, [], array_merge($filters, [
+                '_skip' => $offset,
+                '_limit' => $limit,
+                '_fields' => $fields,
+            ]))
+        );
+
+        if (200 === $result->getReturnCode()) {
+            $responseData = $result->getData();
+
+            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $activity) {
+                $activities[] = new NoteActivity($activity);
+            }
+        }
+
+        return $activities;
+    }
+
+    /**
+     * Gets the information about the note activity that matches the given ID.
+     *
+     * @param string $id The ID of the activity
+     *
+     * @return NoteActivity
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     */
+    public function getNote(string $id): NoteActivity
+    {
+        $result = $this->triggerGet($this->prepareRequest('get-note', null, ['id' => $id]));
+
+        return new NoteActivity($result->getData());
+    }
+
+    /**
+     * Creates a new note activity using the given information.
+     *
+     * @param NoteActivity $activity The information of the activity to create
+     *
+     * @return NoteActivity
+     */
+    public function createNote(NoteActivity $activity): NoteActivity
+    {
+        $apiRequest = $this->prepareRequest('add-note', json_encode($activity));
+
+        return new NoteActivity($this->triggerPost($apiRequest)->getData());
+    }
+
+    /**
+     * Updates the given note activity.
+     *
+     * @param NoteActivity $activity The activity to update
+     *
+     * @return NoteActivity
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     */
+    public function updateNote(NoteActivity $activity): NoteActivity
+    {
+        $id = $activity->getId();
+
+        $activity->setId(null);
+
+        $response = $this->triggerPut($this->prepareRequest('update-note', json_encode($activity), ['id' => $id]));
+
+        return new NoteActivity($response->getData());
+    }
+
+    /**
+     * Deletes the given note activity.
+     *
+     * @param string $activityId The ID of the note activity to delete
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     */
+    public function deleteNote(string $activityId): void
+    {
+        $this->triggerDelete($this->prepareRequest('delete-note', null, ['id' => $activityId]));
+    }
+
+    /**
+     * Gets up to the specified number of SMS activities that match the given
+     * criteria.
+     *
+     * @param int      $offset  The offset from which start getting the items
+     * @param int      $limit   The maximum number of items to get
+     * @param array    $filters A set of criteria to filter the items by
+     * @param string[] $fields  The subset of fields to get (defaults to all)
+     *
+     * @return SmsActivity[]
+     */
+    public function getAllSms(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    {
+        /** @var SmsActivity[] $activities */
+        $activities = [];
+        $result = $this->triggerGet(
+            $this->prepareRequest('list-sms', null, [], array_merge($filters, [
+                '_skip' => $offset,
+                '_limit' => $limit,
+                '_fields' => $fields,
+            ]))
+        );
+
+        if (200 === $result->getReturnCode()) {
+            $responseData = $result->getData();
+
+            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $activity) {
+                $activities[] = new SmsActivity($activity);
+            }
+        }
+
+        return $activities;
+    }
+
+    /**
+     * Gets the information about the SMS activity that matches the given ID.
+     *
+     * @param string $id The ID of the activity
+     *
+     * @return SmsActivity
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     */
+    public function getSms(string $id): SmsActivity
+    {
+        $result = $this->triggerGet($this->prepareRequest('get-sms', null, ['id' => $id]));
+
+        return new SmsActivity($result->getData());
+    }
+
+    /**
+     * Creates a new SMS activity using the given information.
+     *
+     * @param SmsActivity $activity The information of the activity to create
+     *
+     * @return SmsActivity
+     */
+    public function createSms(SmsActivity $activity): SmsActivity
+    {
+        $apiRequest = $this->prepareRequest('add-sms', json_encode($activity));
+
+        return new SmsActivity($this->triggerPost($apiRequest)->getData());
+    }
+
+    /**
+     * Updates the given SMS activity.
+     *
+     * @param SmsActivity $activity The activity to update
+     *
+     * @return SmsActivity
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     */
+    public function updateSms(SmsActivity $activity): SmsActivity
+    {
+        $id = $activity->getId();
+
+        $activity->setId(null);
+
+        $response = $this->triggerPut($this->prepareRequest('update-sms', json_encode($activity), ['id' => $id]));
+
+        return new SmsActivity($response->getData());
+    }
+
+    /**
+     * Deletes the given SMS activity.
+     *
+     * @param string $activityId The ID of the activity to delete
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     */
+    public function deleteSms(string $activityId): void
+    {
+        $this->triggerDelete($this->prepareRequest('delete-sms', null, ['id' => $activityId]));
+    }
+
+    /**
+     * Creates a new note activity using the given information.
+     *
+     * @param NoteActivity $activity The information of the activity to create
+     *
+     * @return NoteActivity
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use createNote() instead.
+     */
+    public function addNote(NoteActivity $activity)
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use createNote() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->createNote($activity);
+    }
+
+    /**
+     * Creates a new call activity using the given information.
+     *
+     * @param CallActivity $activity The information of the call activity to
+     *                               create
+     *
+     * @return CallActivity
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use createCall() instead.
+     */
+    public function addCall(CallActivity $activity)
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use createCall() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->createCall($activity);
+    }
+
+    /**
+     * Creates a new email activity using the given information.
+     *
+     * @param EmailActivity $activity The information of the email activity to
+     *                                create
+     *
+     * @return EmailActivity
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use createEmail() instead.
+     */
+    public function addEmail(EmailActivity $activity)
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use createEmail() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->createEmail($activity);
+    }
+
+    /**
+     * Creates a new SMS activity using the given information.
+     *
+     * @param SmsActivity $activity The information of the activity to create
+     *
+     * @return SmsActivity
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use createSms() instead.
+     */
+    public function addSms(SmsActivity $activity): SmsActivity
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use createSms() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->createSms($activity);
+    }
+
+    /**
+     * Gets the note activities that match the given criteria.
+     *
+     * @param array $filters A set of criteria to filter the items by
      *
      * @return NoteActivity[]
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @deprecated since version 0.8, to be removed in 0.9. Use getAllNotes() instead.
      */
-    public function getNotes(array $filters)
+    public function getNotes(array $filters): array
     {
-        $apiRequest = $this->prepareRequest('get-notes', null, [], $filters);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAllNotes() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        $result = $this->triggerGet($apiRequest);
-
-        $rawData = $result->getData()[CloseIoResponse::GET_RESPONSE_DATA_KEY];
-        $notes = [];
-        foreach ($rawData as $note) {
-            $notes[] = new NoteActivity($note);
-        }
-
-        return $notes;
+        return $this->getAllNotes(0, self::MAX_ITEMS_PER_REQUEST, $filters);
     }
 
     /**
-     * @param array $filters
+     * Gets the call activities that match the given criteria.
+     *
+     * @param array $filters A set of criteria to filter the items by
      *
      * @return CallActivity[]
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @deprecated since version 0.8, to be removed in 0.9. Use getAllCalls() instead.
      */
-    public function getCalls(array $filters)
+    public function getCalls(array $filters): array
     {
-        $apiRequest = $this->prepareRequest('get-calls', null, [], $filters);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAllCalls() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        $result = $this->triggerGet($apiRequest);
-
-        $rawData = $result->getData()[CloseIoResponse::GET_RESPONSE_DATA_KEY];
-        $calls = [];
-        foreach ($rawData as $call) {
-            $calls[] = new CallActivity($call);
-        }
-
-        return $calls;
+        return $this->getAllCalls(0, self::MAX_ITEMS_PER_REQUEST, $filters);
     }
 
     /**
-     * @param array $filters
+     * Gets the email activities that match the given criteria.
+     *
+     * @param array $filters A set of criteria to filter the items by
      *
      * @return EmailActivity[]
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @deprecated since version 0.8, to be removed in 0.9. Use getAllEmails() instead.
      */
-    public function getEmails(array $filters)
+    public function getEmails(array $filters): array
     {
-        $apiRequest = $this->prepareRequest('get-emails', null, [], $filters);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAllEmails() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        $result = $this->triggerGet($apiRequest);
-
-        $rawData = $result->getData()[CloseIoResponse::GET_RESPONSE_DATA_KEY];
-        $calls = [];
-        foreach ($rawData as $call) {
-            $calls[] = new EmailActivity($call);
-        }
-
-        return $calls;
+        return $this->getAllEmails(0, self::MAX_ITEMS_PER_REQUEST, $filters);
     }
 
     /**
-     * @param array $filters
+     * Gets the SMS activities that match the given criteria.
+     *
+     * @param array $filters A set of criteria to filter the items by
      *
      * @return SmsActivity[]
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @deprecated since version 0.8, to be removed in 0.9. Use getAllSms() instead.
      */
-    public function getSmss(array $filters)
+    public function getSmss(array $filters): array
     {
-        $apiRequest = $this->prepareRequest('list-sms', null, [], $filters);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAllSms() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        $result = $this->triggerGet($apiRequest);
-
-        $rawData = $result->getData()[CloseIoResponse::GET_RESPONSE_DATA_KEY];
-        $list = [];
-        foreach ($rawData as $sms) {
-            $list[] = new SmsActivity($sms);
-        }
-
-        return $list;
-    }
-
-    /**
-     * @param string $id
-     *
-     * @return SmsActivity
-     *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
-     */
-    public function getSms($id)
-    {
-        $apiRequest = $this->prepareRequest('get-sms', null, ['id' => $id]);
-
-        $result = $this->triggerGet($apiRequest);
-
-        return new SmsActivity($result->getData());
-    }
-
-    /**
-     * @param SmsActivity $sms
-     *
-     * @return SmsActivity
-     *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
-     */
-    public function updateSms(SmsActivity $sms)
-    {
-        $id = $sms->getId();
-
-        if (empty($id)) {
-            throw new InvalidParamException('When updating a sms you must provide the sms ID');
-        }
-
-        // @see https://developer.close.io/#activities-update-an-sms-activity
-        if (in_array($sms->getStatus(), [SmsActivity::STATUS_DRAFT, SmsActivity::STATUS_SCHEDULED])) {
-            throw new InvalidParamException('When updating a sms it must have the status "draft" or "scheduled"');
-        }
-
-        $sms = json_encode($sms);
-        $apiRequest = $this->prepareRequest('update-sms', $sms, ['id' => $id]);
-
-        $result = $this->triggerPut($apiRequest);
-
-        return new SmsActivity($result->getData());
-    }
-
-    /**
-     * @param SmsActivity $sms
-     *
-     * @return SmsActivity
-     *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
-     */
-    public function addSms(SmsActivity $sms) {
-        $sms = json_encode($sms);
-        $apiRequest = $this->prepareRequest('add-sms', $sms);
-
-        $result = $this->triggerPost($apiRequest);
-
-        return new SmsActivity($result->getData());
-    }
-
-    /**
-     * @param string $id
-     *
-     * @return bool
-     *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
-     */
-    public function deleteSms($id)
-    {
-        $apiRequest = $this->prepareRequest('delete-sms', null, ['id' => $id]);
-
-        $result = $this->triggerDelete($apiRequest);
-
-        return $result->isSuccess();
+        return $this->getAllSms(0, self::MAX_ITEMS_PER_REQUEST, $filters);
     }
 }

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/ActivityApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/ActivityApi.php
@@ -27,7 +27,7 @@ class ActivityApi extends AbstractApi
     /**
      * The maximum number of items that are requested by default
      */
-    public const MAX_ITEMS_PER_REQUEST = 100;
+    private const MAX_ITEMS_PER_REQUEST = 100;
 
     const NAME = 'ActivityApi';
 
@@ -53,7 +53,7 @@ class ActivityApi extends AbstractApi
      *
      * @return Activity[]
      */
-    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    public function list(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
     {
         /** @var Activity[] $activities */
         $activities = [];
@@ -148,16 +148,16 @@ class ActivityApi extends AbstractApi
      *
      * @return NoteActivity[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use NoteActivityApi::getAll() instead.
+     * @deprecated since version 0.8, to be removed in 0.9. Use NoteActivityApi::list() instead.
      */
     public function getNotes(array $filters): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use NoteActivityApi::getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use NoteActivityApi::list() instead.', __METHOD__), E_USER_DEPRECATED);
 
         /** @var NoteActivityApi $apiHandler */
         $apiHandler = $this->getApiHandler()->getApi(NoteActivityApi::NAME);
 
-        return $apiHandler->getAll(0, NoteActivityApi::MAX_ITEMS_PER_REQUEST, $filters);
+        return $apiHandler->list(0, self::MAX_ITEMS_PER_REQUEST, $filters);
     }
 
     /**
@@ -167,16 +167,16 @@ class ActivityApi extends AbstractApi
      *
      * @return CallActivity[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use CallActivityApi::getAll() instead.
+     * @deprecated since version 0.8, to be removed in 0.9. Use CallActivityApi::list() instead.
      */
     public function getCalls(array $filters): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use CallActivityApi::getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use CallActivityApi::list() instead.', __METHOD__), E_USER_DEPRECATED);
 
         /** @var CallActivityApi $apiHandler */
         $apiHandler = $this->getApiHandler()->getApi(CallActivityApi::NAME);
 
-        return $apiHandler->getAll(0, CallActivityApi::MAX_ITEMS_PER_REQUEST, $filters);
+        return $apiHandler->list(0, self::MAX_ITEMS_PER_REQUEST, $filters);
     }
 
     /**
@@ -186,16 +186,16 @@ class ActivityApi extends AbstractApi
      *
      * @return EmailActivity[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use EmailActivityApi::getAll() instead.
+     * @deprecated since version 0.8, to be removed in 0.9. Use EmailActivityApi::list() instead.
      */
     public function getEmails(array $filters): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use EmailActivityApi::getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use EmailActivityApi::list() instead.', __METHOD__), E_USER_DEPRECATED);
 
         /** @var EmailActivityApi $apiHandler */
         $apiHandler = $this->getApiHandler()->getApi(EmailActivityApi::NAME);
 
-        return $apiHandler->getAll(0, EmailActivityApi::MAX_ITEMS_PER_REQUEST, $filters);
+        return $apiHandler->list(0, self::MAX_ITEMS_PER_REQUEST, $filters);
     }
 
     /**
@@ -205,16 +205,16 @@ class ActivityApi extends AbstractApi
      *
      * @return SmsActivity[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use getAllSms() instead.
+     * @deprecated since version 0.8, to be removed in 0.9. Use SmsActivityApi::list() instead.
      */
     public function getSmss(array $filters): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use SmsActivityApi::getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use SmsActivityApi::list() instead.', __METHOD__), E_USER_DEPRECATED);
 
         /** @var SmsActivityApi $apiHandler */
         $apiHandler = $this->getApiHandler()->getApi(SmsActivityApi::NAME);
 
-        return $apiHandler->getAll(0, SmsActivityApi::MAX_ITEMS_PER_REQUEST, $filters);
+        return $apiHandler->list(0, self::MAX_ITEMS_PER_REQUEST, $filters);
     }
 
     /**

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/ActivityApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/ActivityApi.php
@@ -14,6 +14,7 @@ namespace LooplineSystems\CloseIoApiWrapper\Api;
 
 use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
 use LooplineSystems\CloseIoApiWrapper\Library\Api\AbstractApi;
+use LooplineSystems\CloseIoApiWrapper\Library\Exception\BadApiRequestException;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\ResourceNotFoundException;
 use LooplineSystems\CloseIoApiWrapper\Model\Activity;
 use LooplineSystems\CloseIoApiWrapper\Model\CallActivity;
@@ -26,7 +27,7 @@ class ActivityApi extends AbstractApi
     /**
      * The maximum number of items that are requested by default
      */
-    private const MAX_ITEMS_PER_REQUEST = 50;
+    public const MAX_ITEMS_PER_REQUEST = 100;
 
     const NAME = 'ActivityApi';
 
@@ -37,25 +38,7 @@ class ActivityApi extends AbstractApi
     {
         $this->urls = [
             'get-activities' => '/activity/',
-            'get-call' => '/activity/call/[:id]/',
-            'delete-call' => '/activity/call/[:id]/',
-            'add-note' => '/activity/note/',
-            'get-notes' => '/activity/note/',
-            'delete-note' => '/activity/note/[:id]/',
-            'get-note' => '/activity/note/[:id]/',
-            'update-note' => '/activity/note/[:id]/',
-            'add-call' => '/activity/call/',
-            'get-calls' => '/activity/call/',
-            'add-email' => '/activity/email/',
-            'get-emails' => '/activity/email/',
-            'get-email' => '/activity/email/[:id]/',
-            'update-email' => '/activity/email/[:id]/',
-            'delete-email' => '/activity/email/[:id]/',
-            'list-sms' => '/activity/sms/',
-            'add-sms' => '/activity/sms/',
             'delete-sms' => '/activity/sms/[:id]/',
-            'get-sms' => '/activity/sms/[:id]/',
-            'update-sms' => '/activity/sms/[:id]/',
         ];
     }
 
@@ -94,395 +77,24 @@ class ActivityApi extends AbstractApi
     }
 
     /**
-     * Gets up to the specified number of call activities that match the given
-     * criteria.
-     *
-     * @param int      $offset  The offset from which start getting the items
-     * @param int      $limit   The maximum number of items to get
-     * @param array    $filters A set of criteria to filter the items by
-     * @param string[] $fields  The subset of fields to get (defaults to all)
-     *
-     * @return CallActivity[]
-     */
-    public function getAllCalls(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
-    {
-        /** @var CallActivity[] $activities */
-        $activities = [];
-        $result = $this->triggerGet(
-            $this->prepareRequest('get-calls', null, [], array_merge($filters, [
-                '_skip' => $offset,
-                '_limit' => $limit,
-                '_fields' => $fields,
-            ]))
-        );
-
-        if (200 === $result->getReturnCode()) {
-            $responseData = $result->getData();
-
-            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $activity) {
-                $activities[] = new CallActivity($activity);
-            }
-        }
-
-        return $activities;
-    }
-
-    /**
-     * Gets the information about the call activity that matches the given ID.
-     *
-     * @param string $id The ID of the activity
-     *
-     * @return CallActivity
-     *
-     * @throws ResourceNotFoundException If a call activity with the given ID
-     *                                   doesn't exists
-     */
-    public function getCall(string $id): CallActivity
-    {
-        $result = $this->triggerGet($this->prepareRequest('get-call', null, ['id' => $id]));
-
-        return new CallActivity($result->getData());
-    }
-
-    /**
-     * Creates a new call activity using the given information.
-     *
-     * @param CallActivity $callActivity The information of the call activity
-     *                                   to create
-     *
-     * @return CallActivity
-     */
-    public function createCall(CallActivity $callActivity): CallActivity
-    {
-        $apiRequest = $this->prepareRequest('add-call', json_encode($callActivity));
-
-        return new CallActivity($this->triggerPost($apiRequest)->getData());
-    }
-
-    /**
-     * Deletes the given call activity.
-     *
-     * @param string $callActivityId The ID of the call activity to delete
-     *
-     * @throws ResourceNotFoundException If a call activity with the given ID
-     *                                   doesn't exists
-     */
-    public function deleteCall(string $callActivityId): void
-    {
-        $this->triggerDelete($this->prepareRequest('delete-call', null, ['id' => $callActivityId]));
-    }
-
-    /**
-     * Gets up to the specified number of email activities that match the given
-     * criteria.
-     *
-     * @param int      $offset  The offset from which start getting the items
-     * @param int      $limit   The maximum number of items to get
-     * @param array    $filters A set of criteria to filter the items by
-     * @param string[] $fields  The subset of fields to get (defaults to all)
-     *
-     * @return EmailActivity[]
-     */
-    public function getAllEmails(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
-    {
-        /** @var EmailActivity[] $activities */
-        $activities = [];
-        $result = $this->triggerGet(
-            $this->prepareRequest('get-emails', null, [], array_merge($filters, [
-                '_skip' => $offset,
-                '_limit' => $limit,
-                '_fields' => $fields,
-            ]))
-        );
-
-        if (200 === $result->getReturnCode()) {
-            $responseData = $result->getData();
-
-            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $activity) {
-                $activities[] = new CallActivity($activity);
-            }
-        }
-
-        return $activities;
-    }
-
-    /**
-     * Gets the information about the email activity that matches the given ID.
-     *
-     * @param string $id The ID of the activity
-     *
-     * @return EmailActivity
-     *
-     * @throws ResourceNotFoundException If an email activity with the given ID
-     *                                   doesn't exists
-     */
-    public function getEmail(string $id): EmailActivity
-    {
-        $result = $this->triggerGet($this->prepareRequest('get-email', null, ['id' => $id]));
-
-        return new EmailActivity($result->getData());
-    }
-
-    /**
-     * Creates a new email activity using the given information.
-     *
-     * @param EmailActivity $activity The information of the email activity to
-     *                                create
-     *
-     * @return EmailActivity
-     */
-    public function createEmail(EmailActivity $activity): EmailActivity
-    {
-        $apiRequest = $this->prepareRequest('add-email', json_encode($activity));
-
-        return new EmailActivity($this->triggerPost($apiRequest)->getData());
-    }
-
-    /**
-     * Updates the given email activity.
-     *
-     * @param EmailActivity $activity The activity to update
-     *
-     * @return EmailActivity
-     *
-     * @throws ResourceNotFoundException If the activity with the given ID doesn't exists
-     */
-    public function updateEmail(EmailActivity $activity): EmailActivity
-    {
-        $id = $activity->getId();
-
-        $activity->setId(null);
-
-        $response = $this->triggerPut($this->prepareRequest('update-email', json_encode($activity), ['id' => $id]));
-
-        return new EmailActivity($response->getData());
-    }
-
-    /**
-     * Deletes the given email activity.
-     *
-     * @param string $activityId The ID of the email activity to delete
-     *
-     * @throws ResourceNotFoundException If a call activity with the given ID
-     *                                   doesn't exists
-     */
-    public function deleteEmail(string $activityId): void
-    {
-        $this->triggerDelete($this->prepareRequest('delete-email', null, ['id' => $activityId]));
-    }
-
-    /**
-     * Gets up to the specified number of note activities that match the given
-     * criteria.
-     *
-     * @param int      $offset  The offset from which start getting the items
-     * @param int      $limit   The maximum number of items to get
-     * @param array    $filters A set of criteria to filter the items by
-     * @param string[] $fields  The subset of fields to get (defaults to all)
-     *
-     * @return NoteActivity[]
-     */
-    public function getAllNotes(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
-    {
-        /** @var NoteActivity[] $activities */
-        $activities = [];
-        $result = $this->triggerGet(
-            $this->prepareRequest('get-notes', null, [], array_merge($filters, [
-                '_skip' => $offset,
-                '_limit' => $limit,
-                '_fields' => $fields,
-            ]))
-        );
-
-        if (200 === $result->getReturnCode()) {
-            $responseData = $result->getData();
-
-            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $activity) {
-                $activities[] = new NoteActivity($activity);
-            }
-        }
-
-        return $activities;
-    }
-
-    /**
-     * Gets the information about the note activity that matches the given ID.
-     *
-     * @param string $id The ID of the activity
-     *
-     * @return NoteActivity
-     *
-     * @throws ResourceNotFoundException If the activity with the given ID
-     *                                   doesn't exists
-     */
-    public function getNote(string $id): NoteActivity
-    {
-        $result = $this->triggerGet($this->prepareRequest('get-note', null, ['id' => $id]));
-
-        return new NoteActivity($result->getData());
-    }
-
-    /**
-     * Creates a new note activity using the given information.
-     *
-     * @param NoteActivity $activity The information of the activity to create
-     *
-     * @return NoteActivity
-     */
-    public function createNote(NoteActivity $activity): NoteActivity
-    {
-        $apiRequest = $this->prepareRequest('add-note', json_encode($activity));
-
-        return new NoteActivity($this->triggerPost($apiRequest)->getData());
-    }
-
-    /**
-     * Updates the given note activity.
-     *
-     * @param NoteActivity $activity The activity to update
-     *
-     * @return NoteActivity
-     *
-     * @throws ResourceNotFoundException If the activity with the given ID
-     *                                   doesn't exists
-     */
-    public function updateNote(NoteActivity $activity): NoteActivity
-    {
-        $id = $activity->getId();
-
-        $activity->setId(null);
-
-        $response = $this->triggerPut($this->prepareRequest('update-note', json_encode($activity), ['id' => $id]));
-
-        return new NoteActivity($response->getData());
-    }
-
-    /**
-     * Deletes the given note activity.
-     *
-     * @param string $activityId The ID of the note activity to delete
-     *
-     * @throws ResourceNotFoundException If the activity with the given ID
-     *                                   doesn't exists
-     */
-    public function deleteNote(string $activityId): void
-    {
-        $this->triggerDelete($this->prepareRequest('delete-note', null, ['id' => $activityId]));
-    }
-
-    /**
-     * Gets up to the specified number of SMS activities that match the given
-     * criteria.
-     *
-     * @param int      $offset  The offset from which start getting the items
-     * @param int      $limit   The maximum number of items to get
-     * @param array    $filters A set of criteria to filter the items by
-     * @param string[] $fields  The subset of fields to get (defaults to all)
-     *
-     * @return SmsActivity[]
-     */
-    public function getAllSms(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
-    {
-        /** @var SmsActivity[] $activities */
-        $activities = [];
-        $result = $this->triggerGet(
-            $this->prepareRequest('list-sms', null, [], array_merge($filters, [
-                '_skip' => $offset,
-                '_limit' => $limit,
-                '_fields' => $fields,
-            ]))
-        );
-
-        if (200 === $result->getReturnCode()) {
-            $responseData = $result->getData();
-
-            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $activity) {
-                $activities[] = new SmsActivity($activity);
-            }
-        }
-
-        return $activities;
-    }
-
-    /**
-     * Gets the information about the SMS activity that matches the given ID.
-     *
-     * @param string $id The ID of the activity
-     *
-     * @return SmsActivity
-     *
-     * @throws ResourceNotFoundException If the activity with the given ID
-     *                                   doesn't exists
-     */
-    public function getSms(string $id): SmsActivity
-    {
-        $result = $this->triggerGet($this->prepareRequest('get-sms', null, ['id' => $id]));
-
-        return new SmsActivity($result->getData());
-    }
-
-    /**
-     * Creates a new SMS activity using the given information.
-     *
-     * @param SmsActivity $activity The information of the activity to create
-     *
-     * @return SmsActivity
-     */
-    public function createSms(SmsActivity $activity): SmsActivity
-    {
-        $apiRequest = $this->prepareRequest('add-sms', json_encode($activity));
-
-        return new SmsActivity($this->triggerPost($apiRequest)->getData());
-    }
-
-    /**
-     * Updates the given SMS activity.
-     *
-     * @param SmsActivity $activity The activity to update
-     *
-     * @return SmsActivity
-     *
-     * @throws ResourceNotFoundException If the activity with the given ID
-     *                                   doesn't exists
-     */
-    public function updateSms(SmsActivity $activity): SmsActivity
-    {
-        $id = $activity->getId();
-
-        $activity->setId(null);
-
-        $response = $this->triggerPut($this->prepareRequest('update-sms', json_encode($activity), ['id' => $id]));
-
-        return new SmsActivity($response->getData());
-    }
-
-    /**
-     * Deletes the given SMS activity.
-     *
-     * @param string $activityId The ID of the activity to delete
-     *
-     * @throws ResourceNotFoundException If the activity with the given ID
-     *                                   doesn't exists
-     */
-    public function deleteSms(string $activityId): void
-    {
-        $this->triggerDelete($this->prepareRequest('delete-sms', null, ['id' => $activityId]));
-    }
-
-    /**
      * Creates a new note activity using the given information.
      *
      * @param NoteActivity $activity The information of the activity to create
      *
      * @return NoteActivity
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use createNote() instead.
+     * @throws BadApiRequestException If any error occurs during the request
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use NoteActivityApi::create() instead.
      */
     public function addNote(NoteActivity $activity)
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use createNote() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use NoteActivityApi::create() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->createNote($activity);
+        /** @var NoteActivityApi $apiHandler */
+        $apiHandler = $this->getApiHandler()->getApi(NoteActivityApi::NAME);
+
+        return $apiHandler->create($activity);
     }
 
     /**
@@ -493,13 +105,18 @@ class ActivityApi extends AbstractApi
      *
      * @return CallActivity
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use createCall() instead.
+     * @throws BadApiRequestException If any error occurs during the request
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use CallActivityApi::create() instead.
      */
     public function addCall(CallActivity $activity)
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use createCall() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use CallActivityApi::create() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->createCall($activity);
+        /** @var CallActivityApi $apiHandler */
+        $apiHandler = $this->getApiHandler()->getApi(CallActivityApi::NAME);
+
+        return $apiHandler->create($activity);
     }
 
     /**
@@ -510,29 +127,18 @@ class ActivityApi extends AbstractApi
      *
      * @return EmailActivity
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use createEmail() instead.
+     * @throws BadApiRequestException If any error occurs during the request
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use EmailActivityApi::create() instead.
      */
     public function addEmail(EmailActivity $activity)
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use createEmail() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use EmailActivityApi::create() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->createEmail($activity);
-    }
+        /** @var EmailActivityApi $apiHandler */
+        $apiHandler = $this->getApiHandler()->getApi(EmailActivityApi::NAME);
 
-    /**
-     * Creates a new SMS activity using the given information.
-     *
-     * @param SmsActivity $activity The information of the activity to create
-     *
-     * @return SmsActivity
-     *
-     * @deprecated since version 0.8, to be removed in 0.9. Use createSms() instead.
-     */
-    public function addSms(SmsActivity $activity): SmsActivity
-    {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use createSms() instead.', __METHOD__), E_USER_DEPRECATED);
-
-        return $this->createSms($activity);
+        return $apiHandler->create($activity);
     }
 
     /**
@@ -542,13 +148,16 @@ class ActivityApi extends AbstractApi
      *
      * @return NoteActivity[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use getAllNotes() instead.
+     * @deprecated since version 0.8, to be removed in 0.9. Use NoteActivityApi::getAll() instead.
      */
     public function getNotes(array $filters): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAllNotes() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use NoteActivityApi::getAll() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->getAllNotes(0, self::MAX_ITEMS_PER_REQUEST, $filters);
+        /** @var NoteActivityApi $apiHandler */
+        $apiHandler = $this->getApiHandler()->getApi(NoteActivityApi::NAME);
+
+        return $apiHandler->getAll(0, NoteActivityApi::MAX_ITEMS_PER_REQUEST, $filters);
     }
 
     /**
@@ -558,13 +167,16 @@ class ActivityApi extends AbstractApi
      *
      * @return CallActivity[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use getAllCalls() instead.
+     * @deprecated since version 0.8, to be removed in 0.9. Use CallActivityApi::getAll() instead.
      */
     public function getCalls(array $filters): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAllCalls() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use CallActivityApi::getAll() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->getAllCalls(0, self::MAX_ITEMS_PER_REQUEST, $filters);
+        /** @var CallActivityApi $apiHandler */
+        $apiHandler = $this->getApiHandler()->getApi(CallActivityApi::NAME);
+
+        return $apiHandler->getAll(0, CallActivityApi::MAX_ITEMS_PER_REQUEST, $filters);
     }
 
     /**
@@ -574,13 +186,16 @@ class ActivityApi extends AbstractApi
      *
      * @return EmailActivity[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use getAllEmails() instead.
+     * @deprecated since version 0.8, to be removed in 0.9. Use EmailActivityApi::getAll() instead.
      */
     public function getEmails(array $filters): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAllEmails() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use EmailActivityApi::getAll() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->getAllEmails(0, self::MAX_ITEMS_PER_REQUEST, $filters);
+        /** @var EmailActivityApi $apiHandler */
+        $apiHandler = $this->getApiHandler()->getApi(EmailActivityApi::NAME);
+
+        return $apiHandler->getAll(0, EmailActivityApi::MAX_ITEMS_PER_REQUEST, $filters);
     }
 
     /**
@@ -594,8 +209,94 @@ class ActivityApi extends AbstractApi
      */
     public function getSmss(array $filters): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAllSms() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use SmsActivityApi::getAll() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->getAllSms(0, self::MAX_ITEMS_PER_REQUEST, $filters);
+        /** @var SmsActivityApi $apiHandler */
+        $apiHandler = $this->getApiHandler()->getApi(SmsActivityApi::NAME);
+
+        return $apiHandler->getAll(0, SmsActivityApi::MAX_ITEMS_PER_REQUEST, $filters);
+    }
+
+    /**
+     * Gets the information about the SMS activity that matches the given ID.
+     *
+     * @param string $id The ID of the activity
+     *
+     * @return SmsActivity
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use SmsActivityApi::get() instead.
+     */
+    public function getSms(string $id): SmsActivity
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use SmsActivityApi::get() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        /** @var SmsActivityApi $apiHandler */
+        $apiHandler = $this->getApiHandler()->getApi(SmsActivityApi::NAME);
+
+        return $apiHandler->get($id);
+    }
+
+    /**
+     * Updates the given SMS activity.
+     *
+     * @param SmsActivity $activity The activity to update
+     *
+     * @return SmsActivity
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     * @throws BadApiRequestException    If the request contained invalid data
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use SmsActivityApi::update() instead.
+     */
+    public function updateSms(SmsActivity $activity): SmsActivity
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use SmsActivityApi::update() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        /** @var SmsActivityApi $apiHandler */
+        $apiHandler = $this->getApiHandler()->getApi(SmsActivityApi::NAME);
+
+        return $apiHandler->update($activity);
+    }
+
+    /**
+     * Creates a new SMS activity using the given information.
+     *
+     * @param SmsActivity $activity The information of the activity to create
+     *
+     * @return SmsActivity
+     *
+     * @throws BadApiRequestException If any error occurs during the request
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use SmsActivityApi::create() instead.
+     */
+    public function addSms(SmsActivity $activity): SmsActivity
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use SmsActivityApi::create() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        /** @var SmsActivityApi $apiHandler */
+        $apiHandler = $this->getApiHandler()->getApi(SmsActivityApi::NAME);
+
+        return $apiHandler->create($activity);
+    }
+
+    /**
+     * Deletes the given SMS activity.
+     *
+     * @param string $activityId The ID of the activity to delete
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use SmsActivityApi::delete() instead.
+     */
+    public function deleteSms(string $activityId): void
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use SmsActivityApi::delete() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        $this->triggerDelete($this->prepareRequest('delete-sms', null, ['id' => $activityId]));
     }
 }

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/CallActivityApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/CallActivityApi.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Close.io Api Wrapper - LLS Internet GmbH - Loopline Systems
+ *
+ * @link      https://github.com/loopline-systems/closeio-api-wrapper for the canonical source repository
+ * @copyright Copyright (c) 2014 LLS Internet GmbH - Loopline Systems (http://www.loopline-systems.com)
+ * @license   https://github.com/loopline-systems/closeio-api-wrapper/blob/master/LICENSE (MIT Licence)
+ */
+
+namespace LooplineSystems\CloseIoApiWrapper\Api;
+
+use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
+use LooplineSystems\CloseIoApiWrapper\Library\Api\AbstractApi;
+use LooplineSystems\CloseIoApiWrapper\Library\Exception\BadApiRequestException;
+use LooplineSystems\CloseIoApiWrapper\Library\Exception\ResourceNotFoundException;
+use LooplineSystems\CloseIoApiWrapper\Model\CallActivity;
+
+class CallActivityApi extends AbstractApi
+{
+    /**
+     * The maximum number of items that are requested by default
+     */
+    public const MAX_ITEMS_PER_REQUEST = 100;
+
+    const NAME = 'CallActivityApi';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initUrls()
+    {
+        $this->urls = [
+            'get-calls' => '/activity/call/',
+            'get-call' => '/activity/call/[:id]/',
+            'add-call' => '/activity/call/',
+            'delete-call' => '/activity/call/[:id]/',
+        ];
+    }
+
+    /**
+     * Gets up to the specified number of activities that match the given
+     * criteria.
+     *
+     * @param int      $offset  The offset from which start getting the items
+     * @param int      $limit   The maximum number of items to get
+     * @param array    $filters A set of criteria to filter the items by
+     * @param string[] $fields  The subset of fields to get (defaults to all)
+     *
+     * @return CallActivity[]
+     */
+    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    {
+        /** @var CallActivity[] $activities */
+        $activities = [];
+        $result = $this->triggerGet(
+            $this->prepareRequest('get-calls', null, [], array_merge($filters, [
+                '_skip' => $offset,
+                '_limit' => $limit,
+                '_fields' => $fields,
+            ]))
+        );
+
+        if (200 === $result->getReturnCode()) {
+            $responseData = $result->getData();
+
+            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $activity) {
+                $activities[] = new CallActivity($activity);
+            }
+        }
+
+        return $activities;
+    }
+
+    /**
+     * Gets the information about the call activity that matches the given ID.
+     *
+     * @param string   $id     The ID of the activity
+     * @param string[] $fields The subset of fields to get (defaults to all)
+     *
+     * @return CallActivity
+     *
+     * @throws ResourceNotFoundException If a call activity with the given ID
+     *                                   doesn't exists
+     */
+    public function get(string $id, array $fields = []): CallActivity
+    {
+        $apiRequest = $this->prepareRequest('get-call', null, ['id' => $id], ['_fields' => $fields]);
+
+        return new CallActivity($this->triggerGet($apiRequest)->getData());
+    }
+
+    /**
+     * Creates a new call activity using the given information.
+     *
+     * @param CallActivity $activity The information of the call activity
+     *                               to create
+     *
+     * @return CallActivity
+     *
+     * @throws BadApiRequestException
+     */
+    public function create(CallActivity $activity): CallActivity
+    {
+        $apiRequest = $this->prepareRequest('add-call', json_encode($activity));
+
+        return new CallActivity($this->triggerPost($apiRequest)->getData());
+    }
+
+    /**
+     * Deletes the given call activity.
+     *
+     * @param CallActivity $activity The call activity to delete
+     *
+     * @throws ResourceNotFoundException If a call activity with the given ID
+     *                                   doesn't exists
+     */
+    public function delete(CallActivity $activity): void
+    {
+        $id = $activity->getId();
+
+        $activity->setId(null);
+
+        $this->triggerDelete($this->prepareRequest('delete-call', null, ['id' => $id]));
+    }
+}

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/CallActivityApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/CallActivityApi.php
@@ -23,7 +23,7 @@ class CallActivityApi extends AbstractApi
     /**
      * The maximum number of items that are requested by default
      */
-    public const MAX_ITEMS_PER_REQUEST = 100;
+    private const MAX_ITEMS_PER_REQUEST = 100;
 
     const NAME = 'CallActivityApi';
 
@@ -51,7 +51,7 @@ class CallActivityApi extends AbstractApi
      *
      * @return CallActivity[]
      */
-    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    public function list(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
     {
         /** @var CallActivity[] $activities */
         $activities = [];

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/ContactApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/ContactApi.php
@@ -22,7 +22,7 @@ class ContactApi extends AbstractApi
     /**
      * The maximum number of items that are requested by default
      */
-    private const MAX_ITEMS_PER_REQUEST = 50;
+    public const MAX_ITEMS_PER_REQUEST = 100;
 
     const NAME = 'ContactApi';
 
@@ -127,14 +127,15 @@ class ContactApi extends AbstractApi
     /**
      * Deletes the given contact.
      *
-     * @param string $contactId The ID of the contact to delete
-     *
-     * @throws ResourceNotFoundException If a contact with the given ID doesn't
-     *                                   exists
+     * @param Contact $contact The contact to delete
      */
-    public function delete(string $contactId): void
+    public function delete(Contact $contact): void
     {
-        $this->triggerDelete($this->prepareRequest('delete-contact', null, ['id' => $contactId]));
+        $id = $contact->getId();
+
+        $contact->setId(null);
+
+        $this->triggerDelete($this->prepareRequest('delete-contact', null, ['id' => $id]));
     }
 
     /**
@@ -208,17 +209,14 @@ class ContactApi extends AbstractApi
     /**
      * Deletes the given contact.
      *
-     * @param string $contactId The ID of the contact to delete
-     *
-     * @throws ResourceNotFoundException If a contact with the given ID doesn't
-     *                                   exists
+     * @param string $id The ID of the contact to delete
      *
      * @deprecated since version 0.8, to be removed in 0.9. Use delete() instead
      */
-    public function deleteContact($contactId): void
+    public function deleteContact(string $id): void
     {
         @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use delete() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        $this->delete($contactId);
+        $this->triggerDelete($this->prepareRequest('delete-contact', null, ['id' => $id]));
     }
 }

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/ContactApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/ContactApi.php
@@ -22,7 +22,7 @@ class ContactApi extends AbstractApi
     /**
      * The maximum number of items that are requested by default
      */
-    public const MAX_ITEMS_PER_REQUEST = 100;
+    private const MAX_ITEMS_PER_REQUEST = 100;
 
     const NAME = 'ContactApi';
 
@@ -49,7 +49,7 @@ class ContactApi extends AbstractApi
      *
      * @return Contact[]
      */
-    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
+    public function list(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
     {
         /** @var Contact[] $contacts */
         $contacts = [];
@@ -143,13 +143,13 @@ class ContactApi extends AbstractApi
      *
      * @return Contact[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead
+     * @deprecated since version 0.8, to be removed in 0.9. Use list() instead
      */
     public function getAllContacts(): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use list() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->getAll();
+        return $this->list();
     }
 
     /**

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/CustomFieldApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/CustomFieldApi.php
@@ -48,7 +48,7 @@ class CustomFieldApi extends AbstractApi
      *
      * @return CustomField[]
      */
-    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
+    public function list(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
     {
         /** @var CustomField[] $customFields */
         $customFields = [];
@@ -145,13 +145,13 @@ class CustomFieldApi extends AbstractApi
      *
      * @return CustomField[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead
+     * @deprecated since version 0.8, to be removed in 0.9. Use list() instead
      */
     public function getAllCustomFields(): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use list() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->getAll();
+        return $this->list();
     }
 
     /**

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/CustomFieldApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/CustomFieldApi.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 /**
  * Close.io Api Wrapper - LLS Internet GmbH - Loopline Systems
  *
@@ -11,73 +14,158 @@ namespace LooplineSystems\CloseIoApiWrapper\Api;
 
 use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
 use LooplineSystems\CloseIoApiWrapper\Library\Api\AbstractApi;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\BadApiRequestException;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidParamException;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\ResourceNotFoundException;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\UrlNotSetException;
 use LooplineSystems\CloseIoApiWrapper\Model\CustomField;
 
 class CustomFieldApi extends AbstractApi
 {
+    /**
+     * The maximum number of items that are requested by default
+     */
+    private const MAX_ITEMS_PER_REQUEST = 50;
+
     const NAME = 'CustomFieldApi';
 
     protected function initUrls()
     {
         $this->urls = [
-            'get-customFields' => '/custom_fields/lead/',
-            'update-customField' => '/custom_fields/lead/[:id]/'
+            'get-custom-fields' => '/custom_fields/lead/',
+            'get-custom-field' => '/custom_fields/lead/[:id]',
+            'create-custom-field' => '/custom_fields/lead/',
+            'update-custom-field' => '/custom_fields/lead/[:id]/',
+            'delete-custom-field' => '/custom_fields/lead/[:id]/',
         ];
     }
 
     /**
-     * @return CustomField[]
+     * Gets up to the specified number of custom fields that match the given
+     * criteria.
      *
-     * @throws InvalidParamException
-     * @throws BadApiRequestException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @param int   $offset The offset from which start getting the items
+     * @param int   $limit  The maximum number of items to get
+     * @param string[] $fields The subset of fields to get (defaults to all)
+     *
+     * @return CustomField[]
      */
-    public function getAllCustomFields()
+    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
     {
         /** @var CustomField[] $customFields */
         $customFields = [];
+        $result = $this->triggerGet(
+            $this->prepareRequest('get-custom-fields', null, [], [
+                '_skip' => $offset,
+                '_limit' => $limit,
+                '_fields' => $fields,
+            ])
+        );
 
-        $apiRequest = $this->prepareRequest('get-customFields');
+        if (200 === $result->getReturnCode()) {
+            $responseData = $result->getData();
 
-        $result = $this->triggerGet($apiRequest);
-
-        if ($result->getReturnCode() == 200) {
-            $rawData = $result->getData()[CloseIoResponse::GET_RESPONSE_DATA_KEY];
-
-            foreach ($rawData as $customField) {
+            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $customField) {
                 $customFields[] = new CustomField($customField);
             }
         }
+
         return $customFields;
     }
 
     /**
-     * @param CustomField $customField
+     * Gets the information about the custom field that matches the given ID.
+     *
+     * @param string $id The ID of the custom field
      *
      * @return CustomField
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @throws ResourceNotFoundException If a custom field with the given ID
+     *                                   doesn't exists
      */
-    public function updateCustomField(CustomField $customField)
+    public function get(string $id): CustomField
     {
-        if ($customField->getId() == null) {
-            throw new InvalidParamException('When updating a custom field you must provide the custom field ID');
-        }
+        $result = $this->triggerGet($this->prepareRequest('get-custom-field', null, ['id' => $id]));
+
+        return new CustomField($result->getData());
+    }
+
+    /**
+     * Creates a new custom field using the given information.
+     *
+     * @param CustomField $customField The information of the custom field to create
+     *
+     * @return CustomField
+     */
+    public function create(CustomField $customField): CustomField
+    {
+        $apiRequest = $this->prepareRequest('create-custom-field', json_encode($customField));
+
+        return new CustomField($this->triggerPost($apiRequest)->getData());
+    }
+
+    /**
+     * Updates the given custom field.
+     *
+     * @param CustomField $customField The custom field to update
+     *
+     * @return CustomField
+     *
+     * @throws ResourceNotFoundException If a custom field with the given ID
+     *                                   doesn't exists
+     */
+    public function update(CustomField $customField): CustomField
+    {
         $id = $customField->getId();
+
         $customField->setId(null);
 
-        $customField = json_encode($customField);
-        $apiRequest = $this->prepareRequest('update-customField', $customField, ['id' => $id]);
-        $response = $this->triggerPut($apiRequest);
+        $response = $this->triggerPut($this->prepareRequest('update-custom-field', json_encode($customField), ['id' => $id]));
 
         return new CustomField($response->getData());
+    }
+
+    /**
+     * Deletes the given custom field.
+     *
+     * @param string $contactId The ID of the custom field to delete
+     *
+     * @throws ResourceNotFoundException If a custom field with the given ID
+     *                                   doesn't exists
+     */
+    public function delete(string $contactId): void
+    {
+        $this->triggerDelete($this->prepareRequest('delete-custom-field', null, ['id' => $contactId]));
+    }
+
+    /**
+     * Gets all the custom fields of the organization to which the user making
+     * the request belongs to.
+     *
+     * @return CustomField[]
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead
+     */
+    public function getAllCustomFields(): array
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->getAll();
+    }
+
+    /**
+     * Updates the given custom field.
+     *
+     * @param CustomField $customField The custom field to update
+     *
+     * @return CustomField
+     *
+     * @throws ResourceNotFoundException If a custom field with the given ID
+     *                                   doesn't exists
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use update() instead
+     */
+    public function updateCustomField(CustomField $customField): CustomField
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use update() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->update($customField);
     }
 }

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/EmailActivityApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/EmailActivityApi.php
@@ -23,7 +23,7 @@ class EmailActivityApi extends AbstractApi
     /**
      * The maximum number of items that are requested by default
      */
-    public const MAX_ITEMS_PER_REQUEST = 100;
+    private const MAX_ITEMS_PER_REQUEST = 100;
 
     const NAME = 'EmailActivityApi';
 
@@ -52,7 +52,7 @@ class EmailActivityApi extends AbstractApi
      *
      * @return EmailActivity[]
      */
-    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    public function list(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
     {
         /** @var EmailActivity[] $activities */
         $activities = [];

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/EmailActivityApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/EmailActivityApi.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Close.io Api Wrapper - LLS Internet GmbH - Loopline Systems
+ *
+ * @link      https://github.com/loopline-systems/closeio-api-wrapper for the canonical source repository
+ * @copyright Copyright (c) 2014 LLS Internet GmbH - Loopline Systems (http://www.loopline-systems.com)
+ * @license   https://github.com/loopline-systems/closeio-api-wrapper/blob/master/LICENSE (MIT Licence)
+ */
+
+namespace LooplineSystems\CloseIoApiWrapper\Api;
+
+use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
+use LooplineSystems\CloseIoApiWrapper\Library\Api\AbstractApi;
+use LooplineSystems\CloseIoApiWrapper\Library\Exception\BadApiRequestException;
+use LooplineSystems\CloseIoApiWrapper\Library\Exception\ResourceNotFoundException;
+use LooplineSystems\CloseIoApiWrapper\Model\EmailActivity;
+
+class EmailActivityApi extends AbstractApi
+{
+    /**
+     * The maximum number of items that are requested by default
+     */
+    public const MAX_ITEMS_PER_REQUEST = 100;
+
+    const NAME = 'EmailActivityApi';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initUrls()
+    {
+        $this->urls = [
+            'get-emails' => '/activity/email/',
+            'get-email' => '/activity/email/[:id]/',
+            'add-email' => '/activity/email/',
+            'update-email' => '/activity/email/[:id]/',
+            'delete-email' => '/activity/email/[:id]/',
+        ];
+    }
+
+    /**
+     * Gets up to the specified number of email activities that match the given
+     * criteria.
+     *
+     * @param int      $offset  The offset from which start getting the items
+     * @param int      $limit   The maximum number of items to get
+     * @param array    $filters A set of criteria to filter the items by
+     * @param string[] $fields  The subset of fields to get (defaults to all)
+     *
+     * @return EmailActivity[]
+     */
+    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    {
+        /** @var EmailActivity[] $activities */
+        $activities = [];
+        $result = $this->triggerGet(
+            $this->prepareRequest('get-emails', null, [], array_merge($filters, [
+                '_skip' => $offset,
+                '_limit' => $limit,
+                '_fields' => $fields,
+            ]))
+        );
+
+        if (200 === $result->getReturnCode()) {
+            $responseData = $result->getData();
+
+            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $activity) {
+                $activities[] = new EmailActivity($activity);
+            }
+        }
+
+        return $activities;
+    }
+
+    /**
+     * Gets the information about the email activity that matches the given ID.
+     *
+     * @param string   $id     The ID of the activity
+     * @param string[] $fields The subset of fields to get (defaults to all)
+     *
+     * @return EmailActivity
+     *
+     * @throws ResourceNotFoundException If an email activity with the given ID
+     *                                   doesn't exists
+     */
+    public function get(string $id, array $fields = []): EmailActivity
+    {
+        $apiRequest = $this->prepareRequest('get-email', null, ['id' => $id], ['_fields' => $fields]);
+
+        return new EmailActivity($this->triggerGet($apiRequest)->getData());
+    }
+
+    /**
+     * Creates a new email activity using the given information.
+     *
+     * @param EmailActivity $activity The information of the email activity to
+     *                                create
+     *
+     * @return EmailActivity
+     *
+     * @throws BadApiRequestException
+     */
+    public function create(EmailActivity $activity): EmailActivity
+    {
+        $apiRequest = $this->prepareRequest('add-email', json_encode($activity));
+
+        return new EmailActivity($this->triggerPost($apiRequest)->getData());
+    }
+
+    /**
+     * Updates the given email activity.
+     *
+     * @param EmailActivity $activity The activity to update
+     *
+     * @return EmailActivity
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     * @throws BadApiRequestException    If the request contained invalid data
+     */
+    public function update(EmailActivity $activity): EmailActivity
+    {
+        $id = $activity->getId();
+
+        $activity->setId(null);
+
+        $response = $this->triggerPut($this->prepareRequest('update-email', json_encode($activity), ['id' => $id]));
+
+        return new EmailActivity($response->getData());
+    }
+
+    /**
+     * Deletes the given email activity.
+     *
+     * @param EmailActivity $activity The email activity to delete
+     *
+     * @throws ResourceNotFoundException If a call activity with the given ID
+     *                                   doesn't exists
+     */
+    public function delete(EmailActivity $activity): void
+    {
+        $id = $activity->getId();
+
+        $activity->setId(null);
+
+        $this->triggerDelete($this->prepareRequest('delete-email', null, ['id' => $id]));
+    }
+}

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/LeadApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/LeadApi.php
@@ -54,7 +54,7 @@ class LeadApi extends AbstractApi
      *
      * @return Lead[]
      */
-    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    public function list(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
     {
         /** @var Lead[] $leads */
         $leads = [];
@@ -181,13 +181,13 @@ class LeadApi extends AbstractApi
      *
      * @return Lead[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead.
+     * @deprecated since version 0.8, to be removed in 0.9. Use list() instead.
      */
     public function getAllLeads(): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use list() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->getAll();
+        return $this->list();
     }
 
     /**
@@ -197,13 +197,13 @@ class LeadApi extends AbstractApi
      *
      * @return Lead[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead.
+     * @deprecated since version 0.8, to be removed in 0.9. Use list() instead.
      */
     public function findLeads(array $queryParams): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use list() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->getAll(0, self::MAX_ITEMS_PER_REQUEST, $queryParams);
+        return $this->list(0, self::MAX_ITEMS_PER_REQUEST, $queryParams);
     }
 
     /**

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/LeadApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/LeadApi.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 /**
  * Close.io Api Wrapper - LLS Internet GmbH - Loopline Systems
  *
@@ -11,15 +14,18 @@ namespace LooplineSystems\CloseIoApiWrapper\Api;
 
 use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
 use LooplineSystems\CloseIoApiWrapper\Library\Api\AbstractApi;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\BadApiRequestException;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidNewLeadPropertyException;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidParamException;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\ResourceNotFoundException;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\UrlNotSetException;
 use LooplineSystems\CloseIoApiWrapper\Model\Lead;
 
 class LeadApi extends AbstractApi
 {
+    /**
+     * The maximum number of items that are requested by default
+     */
+    private const MAX_ITEMS_PER_REQUEST = 50;
+
     const NAME = 'LeadApi';
 
     /**
@@ -33,30 +39,34 @@ class LeadApi extends AbstractApi
             'get-lead' => '/lead/[:id]/',
             'update-lead' => '/lead/[:id]/',
             'delete-lead' => '/lead/[:id]/',
+            'merge-leads' => '/lead/merge/',
         ];
     }
 
     /**
-     * @return Lead[]
+     * Gets up to the specified number of leads that matches the given criteria.
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @param int   $offset  The offset from which start getting the items
+     * @param int   $limit   The maximum number of items to get
+     * @param array $filters A set of criteria to filter the items by
+     * @param string[] $fields  The subset of fields to get (defaults to all)
+     *
+     * @return Lead[]
      */
-    public function getAllLeads()
+    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
     {
         /** @var Lead[] $leads */
         $leads = [];
+        $result = $this->triggerGet($this->prepareRequest('get-leads', null, [], array_merge($filters, [
+            '_skip' => $offset,
+            '_limit' => $limit,
+            '_fields' => $fields,
+        ])));
 
-        $apiRequest = $this->prepareRequest('get-leads');
+        if (200 === $result->getReturnCode()) {
+            $responseData = $result->getData();
 
-        $result = $this->triggerGet($apiRequest);
-
-        if ($result->getReturnCode() == 200) {
-            $rawData = $result->getData()[CloseIoResponse::GET_RESPONSE_DATA_KEY];
-
-            foreach ($rawData as $lead) {
+            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $lead) {
                 $leads[] = new Lead($lead);
             }
         }
@@ -65,115 +75,196 @@ class LeadApi extends AbstractApi
     }
 
     /**
-     * @param array $queryParams
+     * Gets the information about the lead that matches the given ID.
      *
-     * @return Lead[]
-     *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
-     */
-    public function findLeads(array $queryParams)
-    {
-        /** @var Lead[] $leads */
-        $leads = [];
-        if (count($queryParams) > 0) {
-            $queryParams = ['query' => $this->buildQueryString($queryParams)];
-        }
-        $apiRequest = $this->prepareRequest('get-leads', '', [], $queryParams);
-
-        $result = $this->triggerGet($apiRequest);
-        if ($result->getReturnCode() == 200) {
-            $rawData = $result->getData()['data'];
-            foreach ($rawData as $lead) {
-                $leads[] = new Lead($lead);
-            }
-        }
-
-        return $leads;
-    }
-
-    /**
-     * @param string $id
+     * @param string $id The ID of the lead
      *
      * @return Lead
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @throws ResourceNotFoundException If a lead with the given ID doesn't
+     *                                   exists
      */
-    public function getLead($id)
+    public function get(string $id): Lead
     {
-        $apiRequest = $this->prepareRequest('get-lead', null, ['id' => $id]);
-
-        $result = $this->triggerGet($apiRequest);
+        $result = $this->triggerGet($this->prepareRequest('get-lead', null, ['id' => $id]));
 
         return new Lead($result->getData());
     }
 
     /**
-     * @param Lead $lead
+     * Creates a new lead using the given information.
+     *
+     * @param Lead $lead The information of the lead to create
      *
      * @return Lead
-     *
-     * @throws BadApiRequestException
-     * @throws InvalidNewLeadPropertyException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
      */
-    public function addLead(Lead $lead)
+    public function create(Lead $lead): Lead
     {
         $this->validateLeadForPost($lead);
 
-        $lead = json_encode($lead);
-        $apiRequest = $this->prepareRequest('add-lead', $lead);
+        $apiRequest = $this->prepareRequest('add-lead', json_encode($lead));
 
         return new Lead($this->triggerPost($apiRequest)->getData());
     }
 
     /**
-     * @param Lead $lead
+     * Updates the given lead.
+     *
+     * @param Lead $lead The lead to update
      *
      * @return Lead
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @throws ResourceNotFoundException If a lead with the given ID doesn't
+     *                                   exists
      */
-    public function updateLead(Lead $lead)
+    public function update(Lead $lead): Lead
     {
-        // check if lead has id
-        if ($lead->getId() == null) {
-            throw new InvalidParamException('When updating a lead you must provide the lead ID');
-        }
-        // remove id from lead since it won't be part of the patch data
         $id = $lead->getId();
+
         $lead->setId(null);
 
-        $lead = json_encode($lead);
-        $apiRequest = $this->prepareRequest('update-lead', $lead, ['id' => $id]);
-        $response = $this->triggerPut($apiRequest);
+        $response = $this->triggerPut($this->prepareRequest('update-lead', json_encode($lead), ['id' => $id]));
 
         return new Lead($response->getData());
     }
 
     /**
-     * @param string $id
+     * Deletes the given lead.
      *
-     * @throws InvalidParamException
-     * @throws BadApiRequestException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @param string $leadId The ID of the lead to delete
+     *
+     * @throws ResourceNotFoundException If a lead with the given ID doesn't
+     *                                   exists
      */
-    public function deleteLead($id)
+    public function delete(string $leadId): void
     {
-        $apiRequest = $this->prepareRequest('delete-lead', null, ['id' => $id]);
+        $this->triggerDelete($this->prepareRequest('delete-lead', null, ['id' => $leadId]));
+    }
 
-        $this->triggerDelete($apiRequest);
+    /**
+     * Merges two leads.
+     *
+     * @param Lead $source      The source lead (he will be deleted afterwards)
+     * @param Lead $destination The lead to merge the data in
+     *
+     * @throws InvalidParamException If any of the two leads have an invalid ID
+     * @throws ResourceNotFoundException If the merge fails for whatever reason
+     */
+    public function merge(Lead $source, Lead $destination): void
+    {
+        if (empty($source->getId()) || empty($destination->getId())) {
+            throw new InvalidParamException('You need to specify two already existing leads in order to merge them');
+        }
+
+        $result = $this->triggerPost($this->prepareRequest('merge-leads', json_encode([
+            'destination' => $destination->getId(),
+            'source' => $source->getId(),
+        ])));
+
+        if (!$result->isSuccess()) {
+            throw new ResourceNotFoundException();
+        }
+    }
+
+    /**
+     * Gets all the leads.
+     *
+     * @return Lead[]
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead.
+     */
+    public function getAllLeads(): array
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->getAll();
+    }
+
+    /**
+     * Get all the leads that match the given criteria.
+     *
+     * @param array $queryParams The search criteria
+     *
+     * @return Lead[]
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead.
+     */
+    public function findLeads(array $queryParams): array
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->getAll(0, self::MAX_ITEMS_PER_REQUEST, $queryParams);
+    }
+
+    /**
+     * Gets the lead with the given ID.
+     *
+     * @param string $id The ID of the lead
+     *
+     * @return Lead
+     *
+     * @throws ResourceNotFoundException If a lead with the given ID doesn't
+     *                                   exists
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use get() instead.
+     */
+    public function getLead(string $id): Lead
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use get() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->get($id);
+    }
+
+    /**
+     * Creates a new lead using the given information.
+     *
+     * @param Lead $lead The information of the lead to create
+     *
+     * @return Lead
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use create() instead
+     */
+    public function addLead(Lead $lead): Lead
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use create() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->create($lead);
+    }
+
+    /**
+     * Updates the given lead.
+     *
+     * @param Lead $lead The lead to update
+     *
+     * @return Lead
+     *
+     * @throws ResourceNotFoundException If a lead with the given ID doesn't
+     *                                   exists
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use update() instead
+     */
+    public function updateLead(Lead $lead): Lead
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use update() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->update($lead);
+    }
+
+    /**
+     * Deletes the given lead.
+     *
+     * @param string $id The ID of the lead to delete
+     *
+     * @throws ResourceNotFoundException If a lead with the given ID doesn't
+     *                                   exists
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use delete() instead
+     */
+    public function deleteLead($id): void
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use delete() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        $this->delete($id);
     }
 
     /**
@@ -191,7 +282,6 @@ class LeadApi extends AbstractApi
             }
         }
     }
-
 
     /**
      * @param array $params

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/LeadStatusApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/LeadStatusApi.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 /**
  * Close.io Api Wrapper - LLS Internet GmbH - Loopline Systems
  *
@@ -11,14 +14,16 @@ namespace LooplineSystems\CloseIoApiWrapper\Api;
 
 use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
 use LooplineSystems\CloseIoApiWrapper\Library\Api\AbstractApi;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\BadApiRequestException;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidParamException;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\ResourceNotFoundException;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\UrlNotSetException;
 use LooplineSystems\CloseIoApiWrapper\Model\LeadStatus;
 
 class LeadStatusApi extends AbstractApi
 {
+    /**
+     * The maximum number of items that are requested by default
+     */
+    private const MAX_ITEMS_PER_REQUEST = 50;
+
     const NAME = 'LeadStatusApi';
 
     /**
@@ -36,105 +41,185 @@ class LeadStatusApi extends AbstractApi
     }
 
     /**
-     * @param LeadStatus $status
-     * @return LeadStatus
+     * Gets up to the specified number of lead statuses that match the given
+     * criteria.
      *
-     * @throws InvalidParamException
-     * @throws BadApiRequestException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
-     */
-    public function addStatus(LeadStatus $status)
-    {
-        $status = json_encode($status);
-        $apiRequest = $this->prepareRequest('add-status', $status);
-        $response = $this->triggerPost($apiRequest);
-
-        return new LeadStatus($response->getData());
-    }
-
-    /**
-     * @param LeadStatus $status
+     * @param int   $offset The offset from which start getting the items
+     * @param int   $limit  The maximum number of items to get
+     * @param string[] $fields The subset of fields to get (defaults to all)
      *
-     * @return LeadStatus
-     *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
-     */
-    public function updateStatus(LeadStatus $status)
-    {
-        if ($status->getId() == null) {
-            throw new InvalidParamException('When updating a status you must provide the statuses ID');
-        }
-
-        $id = $status->getId();
-        $status->setId(null);
-
-        $status = json_encode($status);
-        $apiRequest = $this->prepareRequest('update-status', $status, ['id' => $id]);
-        $response = $this->triggerPut($apiRequest);
-
-        return new LeadStatus($response->getData());
-    }
-
-    /**
      * @return LeadStatus[]
-     *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
      */
-    public function getAllStatus()
+    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
     {
-        $statuses = [];
+        /** @var LeadStatus[] $leadStatuses */
+        $leadStatuses = [];
+        $result = $this->triggerGet(
+            $this->prepareRequest('get-statuses', null, [], [
+                '_skip' => $offset,
+                '_limit' => $limit,
+                '_fields' => $fields,
+            ])
+        );
 
-        $apiRequest = $this->prepareRequest('get-statuses');
+        if (200 === $result->getReturnCode()) {
+            $responseData = $result->getData();
 
-        $result = $this->triggerGet($apiRequest);
-
-        if ($result->getReturnCode() == 200) {
-            $rawData = $result->getData()[CloseIoResponse::GET_RESPONSE_DATA_KEY];
-            foreach ($rawData as $status) {
-                $statuses[] = new LeadStatus($status);
+            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $leadStatus) {
+                $leadStatuses[] = new LeadStatus($leadStatus);
             }
         }
-        return $statuses;
+
+        return $leadStatuses;
     }
 
     /**
-     * @param string $id
+     * Gets the information about the lead status that matches the given ID.
+     *
+     * @param string $leadStatusId The ID of the leadStatus
      *
      * @return LeadStatus
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @throws ResourceNotFoundException If a leadStatus with the given ID doesn't
+     *                                   exists
      */
-    public function getStatus($id)
+    public function get(string $leadStatusId): LeadStatus
     {
-        $apiRequest = $this->prepareRequest('get-status', null, ['id' => $id]);
-
-        /** @var CloseIoResponse $result */
-        $result = $this->triggerGet($apiRequest);
+        $result = $this->triggerGet($this->prepareRequest('get-status', null, ['id' => $leadStatusId]));
 
         return new LeadStatus($result->getData());
     }
 
     /**
-     * @param string $id
+     * Creates a new lead status using the given information.
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
+     * @param LeadStatus $leadStatus The information of the leadStatus to create
+     *
+     * @return LeadStatus
      */
-    public function deleteStatus($id){
-        $apiRequest = $this->prepareRequest('delete-status', null, ['id' => $id]);
+    public function create(LeadStatus $leadStatus): LeadStatus
+    {
+        $apiRequest = $this->prepareRequest('add-status', json_encode($leadStatus));
 
-        $this->triggerDelete($apiRequest);
+        return new LeadStatus($this->triggerPost($apiRequest)->getData());
+    }
+
+    /**
+     * Updates the given lead status.
+     *
+     * @param LeadStatus $leadStatus The leadStatus to update
+     *
+     * @return LeadStatus
+     *
+     * @throws ResourceNotFoundException If a leadStatus with the given ID doesn't
+     *                                   exists
+     */
+    public function update(LeadStatus $leadStatus): LeadStatus
+    {
+        $id = $leadStatus->getId();
+
+        $leadStatus->setId(null);
+
+        $response = $this->triggerPut($this->prepareRequest('update-status', json_encode($leadStatus), ['id' => $id]));
+
+        return new LeadStatus($response->getData());
+    }
+
+    /**
+     * Deletes the given lead status.
+     *
+     * @param string $leadStatusId The ID of the leadStatus to delete
+     *
+     * @throws ResourceNotFoundException If a leadStatus with the given ID doesn't
+     *                                   exists
+     */
+    public function delete(string $leadStatusId): void
+    {
+        $this->triggerDelete($this->prepareRequest('delete-status', null, ['id' => $leadStatusId]));
+    }
+
+    /**
+     * Creates a new lead status using the given information.
+     *
+     * @param LeadStatus $leadStatus The information of the leadStatus to create
+     *
+     * @return LeadStatus
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use create() instead
+     */
+    public function addStatus(LeadStatus $leadStatus): LeadStatus
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use create() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->create($leadStatus);
+    }
+
+    /**
+     * Updates the given lead status.
+     *
+     * @param LeadStatus $leadStatus The leadStatus to update
+     *
+     * @return LeadStatus
+     *
+     * @throws ResourceNotFoundException If a leadStatus with the given ID doesn't
+     *                                   exists
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use update() instead
+     */
+    public function updateStatus(LeadStatus $leadStatus): LeadStatus
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use update() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->update($leadStatus);
+    }
+
+    /**
+     * Gets all the lead statuses.
+     *
+     * @return LeadStatus[]
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead
+     */
+    public function getAllStatus(): array
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->getAll();
+    }
+
+    /**
+     * Gets the information about the lead status that matches the given ID.
+     *
+     * @param string $leadStatusId The ID of the leadStatus
+     *
+     * @return LeadStatus
+     *
+     * @throws ResourceNotFoundException If a leadStatus with the given ID doesn't
+     *                                   exists
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use get() instead
+     */
+    public function getStatus(string $leadStatusId): LeadStatus
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use get() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->get($leadStatusId);
+    }
+
+    /**
+     * Deletes the given lead status.
+     *
+     * @param string $leadStatusId The ID of the leadStatus to delete
+     *
+     * @throws ResourceNotFoundException If a leadStatus with the given ID doesn't
+     *                                   exists
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use delete() instead
+     */
+    public function deleteStatus(string $leadStatusId): void
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use delete() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        $this->delete($leadStatusId);
     }
 }

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/LeadStatusApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/LeadStatusApi.php
@@ -14,6 +14,7 @@ namespace LooplineSystems\CloseIoApiWrapper\Api;
 
 use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
 use LooplineSystems\CloseIoApiWrapper\Library\Api\AbstractApi;
+use LooplineSystems\CloseIoApiWrapper\Library\Exception\BadApiRequestException;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\ResourceNotFoundException;
 use LooplineSystems\CloseIoApiWrapper\Model\LeadStatus;
 
@@ -22,7 +23,7 @@ class LeadStatusApi extends AbstractApi
     /**
      * The maximum number of items that are requested by default
      */
-    private const MAX_ITEMS_PER_REQUEST = 50;
+    private const MAX_ITEMS_PER_REQUEST = 100;
 
     const NAME = 'LeadStatusApi';
 
@@ -44,8 +45,8 @@ class LeadStatusApi extends AbstractApi
      * Gets up to the specified number of lead statuses that match the given
      * criteria.
      *
-     * @param int   $offset The offset from which start getting the items
-     * @param int   $limit  The maximum number of items to get
+     * @param int      $offset The offset from which start getting the items
+     * @param int      $limit  The maximum number of items to get
      * @param string[] $fields The subset of fields to get (defaults to all)
      *
      * @return LeadStatus[]
@@ -76,24 +77,25 @@ class LeadStatusApi extends AbstractApi
     /**
      * Gets the information about the lead status that matches the given ID.
      *
-     * @param string $leadStatusId The ID of the leadStatus
+     * @param string   $id     The ID of the lead status
+     * @param string[] $fields The subset of fields to get (defaults to all)
      *
      * @return LeadStatus
      *
-     * @throws ResourceNotFoundException If a leadStatus with the given ID doesn't
+     * @throws ResourceNotFoundException If a lead status with the given ID doesn't
      *                                   exists
      */
-    public function get(string $leadStatusId): LeadStatus
+    public function get(string $id, array $fields = []): LeadStatus
     {
-        $result = $this->triggerGet($this->prepareRequest('get-status', null, ['id' => $leadStatusId]));
+        $apiRequest = $this->prepareRequest('get-status', null, ['id' => $id], ['_fields' => $fields]);
 
-        return new LeadStatus($result->getData());
+        return new LeadStatus($this->triggerGet($apiRequest)->getData());
     }
 
     /**
      * Creates a new lead status using the given information.
      *
-     * @param LeadStatus $leadStatus The information of the leadStatus to create
+     * @param LeadStatus $leadStatus The information of the lead status to create
      *
      * @return LeadStatus
      */
@@ -107,12 +109,13 @@ class LeadStatusApi extends AbstractApi
     /**
      * Updates the given lead status.
      *
-     * @param LeadStatus $leadStatus The leadStatus to update
+     * @param LeadStatus $leadStatus The lead status to update
      *
      * @return LeadStatus
      *
-     * @throws ResourceNotFoundException If a leadStatus with the given ID doesn't
+     * @throws ResourceNotFoundException If a lead status with the given ID doesn't
      *                                   exists
+     * @throws BadApiRequestException    If the request contained invalid data
      */
     public function update(LeadStatus $leadStatus): LeadStatus
     {
@@ -128,20 +131,21 @@ class LeadStatusApi extends AbstractApi
     /**
      * Deletes the given lead status.
      *
-     * @param string $leadStatusId The ID of the leadStatus to delete
-     *
-     * @throws ResourceNotFoundException If a leadStatus with the given ID doesn't
-     *                                   exists
+     * @param LeadStatus $leadStatus The lead status to delete
      */
-    public function delete(string $leadStatusId): void
+    public function delete(LeadStatus $leadStatus): void
     {
-        $this->triggerDelete($this->prepareRequest('delete-status', null, ['id' => $leadStatusId]));
+        $id = $leadStatus->getId();
+
+        $leadStatus->setId(null);
+
+        $this->triggerDelete($this->prepareRequest('delete-status', null, ['id' => $id]));
     }
 
     /**
      * Creates a new lead status using the given information.
      *
-     * @param LeadStatus $leadStatus The information of the leadStatus to create
+     * @param LeadStatus $leadStatus The information of the lead status to create
      *
      * @return LeadStatus
      *
@@ -157,12 +161,12 @@ class LeadStatusApi extends AbstractApi
     /**
      * Updates the given lead status.
      *
-     * @param LeadStatus $leadStatus The leadStatus to update
+     * @param LeadStatus $leadStatus The lead status to update
      *
      * @return LeadStatus
      *
-     * @throws ResourceNotFoundException If a leadStatus with the given ID doesn't
-     *                                   exists
+     * @throws ResourceNotFoundException If a lead status with the given ID
+     *                                   doesn't exists
      *
      * @deprecated since version 0.8, to be removed in 0.9. Use update() instead
      */
@@ -190,12 +194,12 @@ class LeadStatusApi extends AbstractApi
     /**
      * Gets the information about the lead status that matches the given ID.
      *
-     * @param string $leadStatusId The ID of the leadStatus
+     * @param string $leadStatusId The ID of the lead status
      *
      * @return LeadStatus
      *
-     * @throws ResourceNotFoundException If a leadStatus with the given ID doesn't
-     *                                   exists
+     * @throws ResourceNotFoundException If a lead status with the given ID
+     *                                   doesn't exists
      *
      * @deprecated since version 0.8, to be removed in 0.9. Use get() instead
      */
@@ -209,17 +213,17 @@ class LeadStatusApi extends AbstractApi
     /**
      * Deletes the given lead status.
      *
-     * @param string $leadStatusId The ID of the leadStatus to delete
+     * @param string $id The ID of the lead status to delete
      *
-     * @throws ResourceNotFoundException If a leadStatus with the given ID doesn't
-     *                                   exists
+     * @throws ResourceNotFoundException If a lead status with the given ID
+     *                                   doesn't exists
      *
      * @deprecated since version 0.8, to be removed in 0.9. Use delete() instead
      */
-    public function deleteStatus(string $leadStatusId): void
+    public function deleteStatus(string $id): void
     {
         @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use delete() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        $this->delete($leadStatusId);
+        $this->triggerDelete($this->prepareRequest('delete-status', null, ['id' => $id]));
     }
 }

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/LeadStatusApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/LeadStatusApi.php
@@ -51,7 +51,7 @@ class LeadStatusApi extends AbstractApi
      *
      * @return LeadStatus[]
      */
-    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
+    public function list(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
     {
         /** @var LeadStatus[] $leadStatuses */
         $leadStatuses = [];
@@ -182,13 +182,13 @@ class LeadStatusApi extends AbstractApi
      *
      * @return LeadStatus[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead
+     * @deprecated since version 0.8, to be removed in 0.9. Use list() instead
      */
     public function getAllStatus(): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use list() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->getAll();
+        return $this->list();
     }
 
     /**

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/NoteActivityApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/NoteActivityApi.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Close.io Api Wrapper - LLS Internet GmbH - Loopline Systems
+ *
+ * @link      https://github.com/loopline-systems/closeio-api-wrapper for the canonical source repository
+ * @copyright Copyright (c) 2014 LLS Internet GmbH - Loopline Systems (http://www.loopline-systems.com)
+ * @license   https://github.com/loopline-systems/closeio-api-wrapper/blob/master/LICENSE (MIT Licence)
+ */
+
+namespace LooplineSystems\CloseIoApiWrapper\Api;
+
+use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
+use LooplineSystems\CloseIoApiWrapper\Library\Api\AbstractApi;
+use LooplineSystems\CloseIoApiWrapper\Library\Exception\BadApiRequestException;
+use LooplineSystems\CloseIoApiWrapper\Library\Exception\ResourceNotFoundException;
+use LooplineSystems\CloseIoApiWrapper\Model\NoteActivity;
+
+class NoteActivityApi extends AbstractApi
+{
+    /**
+     * The maximum number of items that are requested by default
+     */
+    public const MAX_ITEMS_PER_REQUEST = 100;
+
+    const NAME = 'NoteActivityApi';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initUrls()
+    {
+        $this->urls = [
+            'get-notes' => '/activity/note/',
+            'get-note' => '/activity/note/[:id]/',
+            'add-note' => '/activity/note/',
+            'update-note' => '/activity/note/[:id]/',
+            'delete-note' => '/activity/note/[:id]/',
+        ];
+    }
+
+    /**
+     * Gets up to the specified number of note activities that match the given
+     * criteria.
+     *
+     * @param int      $offset  The offset from which start getting the items
+     * @param int      $limit   The maximum number of items to get
+     * @param array    $filters A set of criteria to filter the items by
+     * @param string[] $fields  The subset of fields to get (defaults to all)
+     *
+     * @return NoteActivity[]
+     */
+    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    {
+        /** @var NoteActivity[] $activities */
+        $activities = [];
+        $result = $this->triggerGet(
+            $this->prepareRequest('get-notes', null, [], array_merge($filters, [
+                '_skip' => $offset,
+                '_limit' => $limit,
+                '_fields' => $fields,
+            ]))
+        );
+
+        if (200 === $result->getReturnCode()) {
+            $responseData = $result->getData();
+
+            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $activity) {
+                $activities[] = new NoteActivity($activity);
+            }
+        }
+
+        return $activities;
+    }
+
+    /**
+     * Gets the information about the note activity that matches the given ID.
+     *
+     * @param string   $id     The ID of the activity
+     * @param string[] $fields The subset of fields to get (defaults to all)
+     *
+     * @return NoteActivity
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     */
+    public function get(string $id, array $fields = []): NoteActivity
+    {
+        $apiRequest = $this->prepareRequest('get-note', null, ['id' => $id], ['_fields' => $fields]);
+
+        return new NoteActivity($this->triggerGet($apiRequest)->getData());
+    }
+
+    /**
+     * Creates a new note activity using the given information.
+     *
+     * @param NoteActivity $activity The information of the activity to create
+     *
+     * @return NoteActivity
+     *
+     * @throws BadApiRequestException
+     */
+    public function create(NoteActivity $activity): NoteActivity
+    {
+        $apiRequest = $this->prepareRequest('add-note', json_encode($activity));
+
+        return new NoteActivity($this->triggerPost($apiRequest)->getData());
+    }
+
+    /**
+     * Updates the given note activity.
+     *
+     * @param NoteActivity $activity The activity to update
+     *
+     * @return NoteActivity
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     * @throws BadApiRequestException    If the request contained invalid data
+     */
+    public function update(NoteActivity $activity): NoteActivity
+    {
+        $id = $activity->getId();
+
+        $activity->setId(null);
+
+        $response = $this->triggerPut($this->prepareRequest('update-note', json_encode($activity), ['id' => $id]));
+
+        return new NoteActivity($response->getData());
+    }
+
+    /**
+     * Deletes the given note activity.
+     *
+     * @param NoteActivity $activity The note activity to delete
+     *sms
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     */
+    public function delete(NoteActivity $activity): void
+    {
+        $id = $activity->getId();
+
+        $activity->setId(null);
+
+        $this->triggerDelete($this->prepareRequest('delete-note', null, ['id' => $id]));
+    }
+}

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/NoteActivityApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/NoteActivityApi.php
@@ -23,7 +23,7 @@ class NoteActivityApi extends AbstractApi
     /**
      * The maximum number of items that are requested by default
      */
-    public const MAX_ITEMS_PER_REQUEST = 100;
+    private const MAX_ITEMS_PER_REQUEST = 100;
 
     const NAME = 'NoteActivityApi';
 
@@ -52,7 +52,7 @@ class NoteActivityApi extends AbstractApi
      *
      * @return NoteActivity[]
      */
-    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    public function list(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
     {
         /** @var NoteActivity[] $activities */
         $activities = [];

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/OpportunityApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/OpportunityApi.php
@@ -52,7 +52,7 @@ class OpportunityApi extends AbstractApi
      *
      * @return Opportunity[]
      */
-    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    public function list(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
     {
         $params = [
             '_skip' => $offset,
@@ -159,13 +159,13 @@ class OpportunityApi extends AbstractApi
      *
      * @return Opportunity[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead
+     * @deprecated since version 0.8, to be removed in 0.9. Use list() instead
      */
     public function getAllOpportunities(): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use list() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->getAll();
+        return $this->list();
     }
 
     /**

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/OpportunityStatusApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/OpportunityStatusApi.php
@@ -22,7 +22,7 @@ class OpportunityStatusApi extends AbstractApi
     /**
      * The maximum number of items that are requested by default
      */
-    private const MAX_ITEMS_PER_REQUEST = 50;
+    private const MAX_ITEMS_PER_REQUEST = 100;
 
     const NAME = 'OpportunityStatus';
 
@@ -77,18 +77,19 @@ class OpportunityStatusApi extends AbstractApi
      * Gets the information about the opportunity status that matches the given
      * ID.
      *
-     * @param string $id The ID of the opportunityStatus
+     * @param string   $id     The ID of the opportunityStatus
+     * @param string[] $fields The subset of fields to get (defaults to all)
      *
      * @return OpportunityStatus
      *
      * @throws ResourceNotFoundException If an opportunity status with the given
      *                                   ID doesn't exists
      */
-    public function get(string $id): OpportunityStatus
+    public function get(string $id, array $fields = []): OpportunityStatus
     {
-        $result = $this->triggerGet($this->prepareRequest('get-status', null, ['id' => $id]));
+        $apiRequest = $this->prepareRequest('get-status', null, ['id' => $id], ['_fields' => $fields]);
 
-        return new OpportunityStatus($result->getData());
+        return new OpportunityStatus($this->triggerGet($apiRequest)->getData());
     }
 
     /**
@@ -129,14 +130,15 @@ class OpportunityStatusApi extends AbstractApi
     /**
      * Deletes the given opportunity status.
      *
-     * @param string $opportunityStatusId The ID of the opportunity status to delete
-     *
-     * @throws ResourceNotFoundException If an opportunity status with the given
-     *                                   ID doesn't exists
+     * @param OpportunityStatus $opportunityStatus The opportunity status to delete
      */
-    public function delete(string $opportunityStatusId): void
+    public function delete(OpportunityStatus $opportunityStatus): void
     {
-        $this->triggerDelete($this->prepareRequest('delete-status', null, ['id' => $opportunityStatusId]));
+        $id = $opportunityStatus->getId();
+
+        $opportunityStatus->setId(null);
+
+        $this->triggerDelete($this->prepareRequest('delete-status', null, ['id' => $id]));
     }
 
     /**
@@ -183,6 +185,8 @@ class OpportunityStatusApi extends AbstractApi
      */
     public function getAllStatus(): array
     {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+
         return $this->getAll();
     }
 
@@ -207,17 +211,14 @@ class OpportunityStatusApi extends AbstractApi
     /**
      * Deletes the given opportunity status.
      *
-     * @param string $opportunityStatusId The ID of the opportunity status to delete
-     *
-     * @throws ResourceNotFoundException If an opportunity status with the given
-     *                                   ID doesn't exists
+     * @param string $id The ID of the opportunity status to delete
      *
      * @deprecated since version 0.8, to be removed in 0.9. Use delete() instead
      */
-    public function deleteStatus(string $opportunityStatusId): void
+    public function deleteStatus(string $id): void
     {
         @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use delete() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        $this->delete($opportunityStatusId);
+        $this->triggerDelete($this->prepareRequest('delete-status', null, ['id' => $id]));
     }
 }

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/OpportunityStatusApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/OpportunityStatusApi.php
@@ -50,7 +50,7 @@ class OpportunityStatusApi extends AbstractApi
      *
      * @return OpportunityStatus[]
      */
-    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
+    public function list(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
     {
         /** @var OpportunityStatus[] $leadStatuses */
         $leadStatuses = [];
@@ -181,13 +181,13 @@ class OpportunityStatusApi extends AbstractApi
      *
      * @return OpportunityStatus[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead
+     * @deprecated since version 0.8, to be removed in 0.9. Use list() instead
      */
     public function getAllStatus(): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use list() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->getAll();
+        return $this->list();
     }
 
     /**

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/SmsActivityApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/SmsActivityApi.php
@@ -23,7 +23,7 @@ class SmsActivityApi extends AbstractApi
     /**
      * The maximum number of items that are requested by default
      */
-    public const MAX_ITEMS_PER_REQUEST = 100;
+    private const MAX_ITEMS_PER_REQUEST = 100;
 
     const NAME = 'SmsActivityApi';
 
@@ -52,7 +52,7 @@ class SmsActivityApi extends AbstractApi
      *
      * @return SmsActivity[]
      */
-    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    public function list(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
     {
         /** @var SmsActivity[] $activities */
         $activities = [];

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/SmsActivityApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/SmsActivityApi.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Close.io Api Wrapper - LLS Internet GmbH - Loopline Systems
+ *
+ * @link      https://github.com/loopline-systems/closeio-api-wrapper for the canonical source repository
+ * @copyright Copyright (c) 2014 LLS Internet GmbH - Loopline Systems (http://www.loopline-systems.com)
+ * @license   https://github.com/loopline-systems/closeio-api-wrapper/blob/master/LICENSE (MIT Licence)
+ */
+
+namespace LooplineSystems\CloseIoApiWrapper\Api;
+
+use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
+use LooplineSystems\CloseIoApiWrapper\Library\Api\AbstractApi;
+use LooplineSystems\CloseIoApiWrapper\Library\Exception\BadApiRequestException;
+use LooplineSystems\CloseIoApiWrapper\Library\Exception\ResourceNotFoundException;
+use LooplineSystems\CloseIoApiWrapper\Model\SmsActivity;
+
+class SmsActivityApi extends AbstractApi
+{
+    /**
+     * The maximum number of items that are requested by default
+     */
+    public const MAX_ITEMS_PER_REQUEST = 100;
+
+    const NAME = 'SmsActivityApi';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initUrls()
+    {
+        $this->urls = [
+            'list-sms' => '/activity/sms/',
+            'get-sms' => '/activity/sms/[:id]/',
+            'add-sms' => '/activity/sms/',
+            'update-sms' => '/activity/sms/[:id]/',
+            'delete-sms' => '/activity/sms/[:id]/',
+        ];
+    }
+
+    /**
+     * Gets up to the specified number of SMS activities that match the given
+     * criteria.
+     *
+     * @param int      $offset  The offset from which start getting the items
+     * @param int      $limit   The maximum number of items to get
+     * @param array    $filters A set of criteria to filter the items by
+     * @param string[] $fields  The subset of fields to get (defaults to all)
+     *
+     * @return SmsActivity[]
+     */
+    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $filters = [], array $fields = []): array
+    {
+        /** @var SmsActivity[] $activities */
+        $activities = [];
+        $result = $this->triggerGet(
+            $this->prepareRequest('list-sms', null, [], array_merge($filters, [
+                '_skip' => $offset,
+                '_limit' => $limit,
+                '_fields' => $fields,
+            ]))
+        );
+
+        if (200 === $result->getReturnCode()) {
+            $responseData = $result->getData();
+
+            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $activity) {
+                $activities[] = new SmsActivity($activity);
+            }
+        }
+
+        return $activities;
+    }
+
+    /**
+     * Gets the information about the SMS activity that matches the given ID.
+     *
+     * @param string   $id     The ID of the activity
+     * @param string[] $fields The subset of fields to get (defaults to all)
+     *
+     * @return SmsActivity
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     */
+    public function get(string $id, array $fields = []): SmsActivity
+    {
+        $apiRequest = $this->prepareRequest('get-sms', null, ['id' => $id], ['_fields' => $fields]);
+
+        return new SmsActivity($this->triggerGet($apiRequest)->getData());
+    }
+
+    /**
+     * Creates a new SMS activity using the given information.
+     *
+     * @param SmsActivity $activity The information of the activity to create
+     *
+     * @return SmsActivity
+     *
+     * @throws BadApiRequestException
+     */
+    public function create(SmsActivity $activity): SmsActivity
+    {
+        $apiRequest = $this->prepareRequest('add-sms', json_encode($activity));
+
+        return new SmsActivity($this->triggerPost($apiRequest)->getData());
+    }
+
+    /**
+     * Updates the given SMS activity.
+     *
+     * @param SmsActivity $activity The activity to update
+     *
+     * @return SmsActivity
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     * @throws BadApiRequestException    If the request contained invalid data
+     */
+    public function update(SmsActivity $activity): SmsActivity
+    {
+        $id = $activity->getId();
+
+        $activity->setId(null);
+
+        $response = $this->triggerPut($this->prepareRequest('update-sms', json_encode($activity), ['id' => $id]));
+
+        return new SmsActivity($response->getData());
+    }
+
+    /**
+     * Deletes the given SMS activity.
+     *
+     * @param SmsActivity $activity The activity to delete
+     *
+     * @throws ResourceNotFoundException If the activity with the given ID
+     *                                   doesn't exists
+     * @throws BadApiRequestException    If the request contained invalid data
+     */
+    public function delete(SmsActivity $activity): void
+    {
+        $id = $activity->getId();
+
+        $activity->setId(null);
+
+        $this->triggerDelete($this->prepareRequest('delete-sms', null, ['id' => $id]));
+    }
+}

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/TaskApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/TaskApi.php
@@ -23,7 +23,7 @@ class TaskApi extends AbstractApi
     /**
      * The maximum number of items that are requested by default
      */
-    public const MAX_ITEMS_PER_REQUEST = 100;
+    private const MAX_ITEMS_PER_REQUEST = 100;
 
     const NAME = 'TaskApi';
 
@@ -50,7 +50,7 @@ class TaskApi extends AbstractApi
      *
      * @return Task[]
      */
-    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
+    public function list(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
     {
         /** @var Task[] $tasks */
         $tasks = [];
@@ -152,11 +152,11 @@ class TaskApi extends AbstractApi
      *
      * @return Task[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead
+     * @deprecated since version 0.8, to be removed in 0.9. Use list() instead
      */
     public function getAllTasks(): array
     {
-        return $this->getAll();
+        return $this->list();
     }
 
     /**

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/UserApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/UserApi.php
@@ -22,7 +22,7 @@ class UserApi extends AbstractApi
     /**
      * The maximum number of items that are requested by default
      */
-    public const MAX_ITEMS_PER_REQUEST = 100;
+    private const MAX_ITEMS_PER_REQUEST = 100;
 
     const NAME = 'UserApi';
 
@@ -48,7 +48,7 @@ class UserApi extends AbstractApi
      *
      * @return User[]
      */
-    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
+    public function list(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
     {
         /** @var User[] $users */
         $users = [];
@@ -127,13 +127,13 @@ class UserApi extends AbstractApi
      *
      * @return User[]
      *
-     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead
+     * @deprecated since version 0.8, to be removed in 0.9. Use list() instead
      */
     public function getAllUsers(): array
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use list() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return $this->getAll();
+        return $this->list();
     }
 
     /**

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/UserApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/UserApi.php
@@ -22,7 +22,7 @@ class UserApi extends AbstractApi
     /**
      * The maximum number of items that are requested by default
      */
-    private const MAX_ITEMS_PER_REQUEST = 50;
+    public const MAX_ITEMS_PER_REQUEST = 100;
 
     const NAME = 'UserApi';
 

--- a/src/LooplineSystems/CloseIoApiWrapper/Api/UserApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Api/UserApi.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 /**
  * Close.io Api Wrapper - LLS Internet GmbH - Loopline Systems
  *
@@ -11,15 +14,16 @@ namespace LooplineSystems\CloseIoApiWrapper\Api;
 
 use LooplineSystems\CloseIoApiWrapper\CloseIoResponse;
 use LooplineSystems\CloseIoApiWrapper\Library\Api\AbstractApi;
-use LooplineSystems\CloseIoApiWrapper\Library\Curl\Curl;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\BadApiRequestException;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidParamException;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\ResourceNotFoundException;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\UrlNotSetException;
 use LooplineSystems\CloseIoApiWrapper\Model\User;
 
 class UserApi extends AbstractApi
 {
+    /**
+     * The maximum number of items that are requested by default
+     */
+    private const MAX_ITEMS_PER_REQUEST = 50;
+
     const NAME = 'UserApi';
 
     /**
@@ -35,48 +39,31 @@ class UserApi extends AbstractApi
     }
 
     /**
-     * @return User
+     * Gets all the users who are members of the same organizations as the user
+     * currently making the request.
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws ResourceNotFoundException
-     * @throws UrlNotSetException
-     */
-    public function getCurrentUser()
-    {
-        $apiRequest = $this->prepareRequest('get-current-user');
-
-        $result = $this->triggerGet($apiRequest);
-
-        if ($result->getReturnCode() == 200 && (!empty($result->getData()))) {
-            $user = new User($result->getData());
-        } else {
-            throw new ResourceNotFoundException();
-        }
-
-        return $user;
-    }
-
-    /**
+     * @param int      $offset    The offset from which start getting the items
+     * @param int      $limit     The maximum number of items to get
+     * @param string[] $fields The subset of fields to get (defaults to all)
+     *
      * @return User[]
-     *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws UrlNotSetException
-     * @throws ResourceNotFoundException
      */
-    public function getAllUsers()
+    public function getAll(int $offset = 0, int $limit = self::MAX_ITEMS_PER_REQUEST, array $fields = []): array
     {
         /** @var User[] $users */
-        $users = array();
+        $users = [];
+        $result = $this->triggerGet(
+            $this->prepareRequest('get-users', null, [], [
+                '_skip' => $offset,
+                '_limit' => $limit,
+                '_fields' => $fields,
+            ])
+        );
 
-        $apiRequest = $this->prepareRequest('get-users');
+        if (200 === $result->getReturnCode()) {
+            $responseData = $result->getData();
 
-        $result = $this->triggerGet($apiRequest);
-
-        if ($result->getReturnCode() == 200) {
-            $rawData = $result->getData()[CloseIoResponse::GET_RESPONSE_DATA_KEY];
-            foreach ($rawData as $user) {
+            foreach ($responseData[CloseIoResponse::GET_RESPONSE_DATA_KEY] as $user) {
                 $users[] = new User($user);
             }
         }
@@ -85,36 +72,85 @@ class UserApi extends AbstractApi
     }
 
     /**
-     * @param string $id
+     * Gets the information about the user that matches the given ID.
+     *
+     * @param string $id The ID of the user
+     *
      * @return User
      *
-     * @throws BadApiRequestException
-     * @throws InvalidParamException
-     * @throws ResourceNotFoundException
-     * @throws UrlNotSetException
+     * @throws ResourceNotFoundException If a user with the given ID doesn't exists
      */
-    public function getUser($id)
+    public function get(string $id): User
     {
-        $apiRequest = $this->prepareRequest('get-user', null, ['id' => $id]);
+        $result = $this->triggerGet($this->prepareRequest('get-user', null, ['id' => $id]));
 
-        $result = $this->triggerGet($apiRequest);
-
-        if ($result->getReturnCode() == 200 && (!empty($result->getData()))) {
-            $user = new User($result->getData());
-        } else {
-            throw new ResourceNotFoundException();
-        }
-
-        return $user;
+        return new User($result->getData());
     }
 
     /**
-     * @param User $user
-     * @return bool
+     * Gets the information about the current logged-in user.
+     *
+     * @return User
+     *
+     * @throws ResourceNotFoundException
      */
-    public function validateUserForPost(User $user)
+    public function getCurrent(): User
     {
-        return true;
+        $result = $this->triggerGet($this->prepareRequest('get-current-user'));
+        $responseData = $result->getData();
+
+        if (200 === $result->getReturnCode() && !empty($responseData)) {
+            return new User($responseData);
+        }
+
+        throw new ResourceNotFoundException();
     }
 
+    /**
+     * Gets the information about the current logged-in user.
+     *
+     * @return User
+     *
+     * @throws ResourceNotFoundException
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use getCurrent() instead
+     */
+    public function getCurrentUser(): User
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getCurrent() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->getCurrent();
+    }
+
+    /**
+     * Gets all the users.
+     *
+     * @return User[]
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use getAll() instead
+     */
+    public function getAllUsers(): array
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use getAll() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->getAll();
+    }
+
+    /**
+     * Gets the information about the user that matches the given ID.
+     *
+     * @param string $id The ID of the user
+     *
+     * @return User
+     *
+     * @throws ResourceNotFoundException If a user with the given ID doesn't exists
+     *
+     * @deprecated since version 0.8, to be removed in 0.9. Use get() instead
+     */
+    public function getUser(string $id): User
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 0.8. Use get() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->get($id);
+    }
 }

--- a/src/LooplineSystems/CloseIoApiWrapper/CloseIoApiWrapper.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/CloseIoApiWrapper.php
@@ -10,16 +10,19 @@
 namespace LooplineSystems\CloseIoApiWrapper;
 
 use LooplineSystems\CloseIoApiWrapper\Api\ActivityApi;
+use LooplineSystems\CloseIoApiWrapper\Api\CallActivityApi;
 use LooplineSystems\CloseIoApiWrapper\Api\ContactApi;
 use LooplineSystems\CloseIoApiWrapper\Api\CustomFieldApi;
+use LooplineSystems\CloseIoApiWrapper\Api\EmailActivityApi;
 use LooplineSystems\CloseIoApiWrapper\Api\LeadApi;
 use LooplineSystems\CloseIoApiWrapper\Api\LeadStatusApi;
+use LooplineSystems\CloseIoApiWrapper\Api\NoteActivityApi;
 use LooplineSystems\CloseIoApiWrapper\Api\OpportunityApi;
 use LooplineSystems\CloseIoApiWrapper\Api\OpportunityStatusApi;
+use LooplineSystems\CloseIoApiWrapper\Api\SmsActivityApi;
 use LooplineSystems\CloseIoApiWrapper\Api\TaskApi;
 use LooplineSystems\CloseIoApiWrapper\Api\UserApi;
 use LooplineSystems\CloseIoApiWrapper\Library\Api\ApiHandler;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\ApiNotFoundException;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidParamException;
 
 class CloseIoApiWrapper
@@ -56,6 +59,10 @@ class CloseIoApiWrapper
         $apiHandler->setApi(new CustomFieldApi($apiHandler));
         $apiHandler->setApi(new ContactApi($apiHandler));
         $apiHandler->setApi(new ActivityApi($apiHandler));
+        $apiHandler->setApi(new CallActivityApi($apiHandler));
+        $apiHandler->setApi(new SmsActivityApi($apiHandler));
+        $apiHandler->setApi(new EmailActivityApi($apiHandler));
+        $apiHandler->setApi(new NoteActivityApi($apiHandler));
         $apiHandler->setApi(new TaskApi($apiHandler));
         $apiHandler->setApi(new UserApi($apiHandler));
 
@@ -135,6 +142,50 @@ class CloseIoApiWrapper
     {
         /** @var ActivityApi $api */
         $api = $this->apiHandler->getApi(ActivityApi::NAME);
+
+        return $api;
+    }
+
+    /**
+     * @return CallActivityApi
+     */
+    public function getCallActivitiesApi()
+    {
+        /** @var CallActivityApi $api */
+        $api = $this->apiHandler->getApi(CallActivityApi::NAME);
+
+        return $api;
+    }
+
+    /**
+     * @return SmsActivityApi
+     */
+    public function getSmsActivitiesApi()
+    {
+        /** @var SmsActivityApi $api */
+        $api = $this->apiHandler->getApi(SmsActivityApi::NAME);
+
+        return $api;
+    }
+
+    /**
+     * @return EmailActivityApi
+     */
+    public function getEmailActivitiesApi()
+    {
+        /** @var EmailActivityApi $api */
+        $api = $this->apiHandler->getApi(EmailActivityApi::NAME);
+
+        return $api;
+    }
+
+    /**
+     * @return NoteActivityApi
+     */
+    public function getNoteActivitiesApi()
+    {
+        /** @var NoteActivityApi $api */
+        $api = $this->apiHandler->getApi(NoteActivityApi::NAME);
 
         return $api;
     }

--- a/src/LooplineSystems/CloseIoApiWrapper/Library/Api/AbstractApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Library/Api/AbstractApi.php
@@ -201,6 +201,14 @@ abstract class AbstractApi implements ApiInterface
         $url = $this->prepareUrlForKey($urlKey, $urlReplacements);
 
         if (!empty($queryParams)) {
+            if (empty($queryParams['_fields'])) {
+                unset($queryParams['_fields']);
+            }
+
+            if (isset($queryParams['_fields']) && is_array($queryParams['_fields'])) {
+                $queryParams['_fields'] = implode(',', $queryParams['_fields']);
+            }
+
             $url .= '?' . http_build_query($queryParams);
         }
 

--- a/src/LooplineSystems/CloseIoApiWrapper/Library/Api/AbstractApi.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Library/Api/AbstractApi.php
@@ -206,6 +206,7 @@ abstract class AbstractApi implements ApiInterface
             }
 
             if (isset($queryParams['_fields']) && is_array($queryParams['_fields'])) {
+                $queryParams['_fields'] = array_unique(array_merge($queryParams['_fields'], ['id']));
                 $queryParams['_fields'] = implode(',', $queryParams['_fields']);
             }
 

--- a/tests/LooplineSystems/CloseIoApiWrapper/Api/ActivityApiTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Api/ActivityApiTest.php
@@ -19,9 +19,20 @@ use LooplineSystems\CloseIoApiWrapper\Model\SmsActivity;
 class ActivityApiTest extends \PHPUnit\Framework\TestCase
 {
     /**
+     * @var CloseIoApiWrapper
+     */
+    private $closeIoApiWrapper;
+
+    protected function setUp()
+    {
+        $closeIoConfig = new CloseIoConfig();
+        $closeIoConfig->setApiKey('testapikey');
+
+        $this->closeIoApiWrapper = new CloseIoApiWrapper($closeIoConfig);
+    }
+
+    /**
      * @description tests updating a sms activity using mock curl object
-     *
-     * @throws \LooplineSystems\CloseIoApiWrapper\Library\Exception\ApiNotFoundException
      */
     public function testUpdateSms()
     {
@@ -29,7 +40,8 @@ class ActivityApiTest extends \PHPUnit\Framework\TestCase
         $sms->setId('test-124');
         $sms->setLocalPhone('+123456789');
 
-        $activityApi = $this->getActivityApi();
+        $activitiesApi = $this->closeIoApiWrapper->getActivitiesApi();
+        $smsActivitiesApi = $this->closeIoApiWrapper->getSmsActivitiesApi();
 
         $returnedSms = clone $sms;
 
@@ -38,9 +50,9 @@ class ActivityApiTest extends \PHPUnit\Framework\TestCase
         $expectedResponse->setRawData(json_encode($returnedSms));
         $expectedResponse->setData(json_decode($expectedResponse->getRawData(), true));
 
-        $activityApi->setCurl($this->getMockResponderCurl($expectedResponse));
+        $smsActivitiesApi->setCurl($this->getMockResponderCurl($expectedResponse));
 
-        $responseSms = $activityApi->addSms($sms);
+        $responseSms = $activitiesApi->addSms($sms);
 
         $this->assertTrue($responseSms->getLocalPhone() === $sms->getLocalPhone());
         $this->assertNotEmpty($responseSms->getId());
@@ -48,33 +60,17 @@ class ActivityApiTest extends \PHPUnit\Framework\TestCase
 
     public function testDeleteSms()
     {
-        $activityApi = $this->getActivityApi();
+        $activitiesApi = $this->closeIoApiWrapper->getActivitiesApi();
 
         $id = 'sms-to-be-deleted';
 
-        // init expected response
         $expectedResponse = new CloseIoResponse();
         $expectedResponse->setReturnCode('200');
-        $expectedResponse->setCurlInfoRaw(['url' => $activityApi->getApiHandler()->getConfig()->getUrl() . $id]);
+        $expectedResponse->setCurlInfoRaw(['url' => $activitiesApi->getApiHandler()->getConfig()->getUrl() . $id]);
 
-        // create stub
-        $mockCurl = $this->getMockResponderCurl($expectedResponse);
-        $activityApi->setCurl($mockCurl);
+        $activitiesApi->setCurl($this->getMockResponderCurl($expectedResponse));
 
-        $activityApi->deleteSms($id);
-    }
-
-    /**
-     * @return ActivityApi
-     */
-    private function getActivityApi()
-    {
-        // init wrapper
-        $closeIoConfig = new CloseIoConfig();
-        $closeIoConfig->setApiKey('testapikey');
-        $closeIoApiWrapper = new CloseIoApiWrapper($closeIoConfig);
-
-        return $closeIoApiWrapper->getActivitiesApi();
+        $activitiesApi->deleteSms($id);
     }
 
     /**

--- a/tests/LooplineSystems/CloseIoApiWrapper/Api/ActivityApiTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Api/ActivityApiTest.php
@@ -61,7 +61,7 @@ class ActivityApiTest extends \PHPUnit\Framework\TestCase
         $mockCurl = $this->getMockResponderCurl($expectedResponse);
         $activityApi->setCurl($mockCurl);
 
-        $this->assertTrue($activityApi->deleteSms($id), 'should return true on delete');
+        $activityApi->deleteSms($id);
     }
 
     /**

--- a/tests/LooplineSystems/CloseIoApiWrapper/Library/Curl/CurlTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Library/Curl/CurlTest.php
@@ -13,7 +13,6 @@ use LooplineSystems\CloseIoApiWrapper\CloseIoRequest;
 use LooplineSystems\CloseIoApiWrapper\CloseIoApiWrapper;
 use LooplineSystems\CloseIoApiWrapper\CloseIoConfig;
 use LooplineSystems\CloseIoApiWrapper\Library\Curl\Curl;
-use LooplineSystems\CloseIoApiWrapper\Library\Exception\BadApiRequestException;
 
 class CurlTest extends \PHPUnit\Framework\TestCase
 {
@@ -32,19 +31,6 @@ class CurlTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($response->getReturnCode(), '200');
         $this->assertNotEmpty($response->getRawData());
         $this->assertFalse($response->hasErrors());
-    }
-
-    public function testBadRequest()
-    {
-        $config = new CloseIoConfig();
-        $config->setApiKey('testkey');
-        $closeIoApiWrapper = new CloseIoApiWrapper($config);
-
-        $leadApi = $closeIoApiWrapper->getLeadApi();
-
-        $this->expectException(BadApiRequestException::class);
-
-        $leadApi->getLead('bad-id');
     }
 
     public function testInterface()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   | yes
| License       | MIT

This PR is an initial refactoring of the classes that handle the APIs by exposing common methods to interact with each resource type. I've tried to standardize the naming of those methods, added typehints and docblocks so that everything is well documented and clear. There are some BC breaks (e.g. the delete methods do not return `boolean` anymore). I've also added the deprecation warning to all methods that should be removed in a later release