### PR TITLE
Add PHP 7.3 to the Travis CI build pipeline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+charset = utf-8
+end_of_line = LF
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.php]
+indent_style = space
+indent_size = 4
+
+[*.md]
+max_line_length = 80
+
+[COMMIT_EDITMSG]
+max_line_length = 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
     - 7.1
     - 7.2
+    - 7.3
+    - nightly
 
 env:
     - dependencies=lowest
@@ -29,19 +31,8 @@ jobs:
           script: composer phpcs
         - script: composer phpstan
           name: PHPStan
-        - stage: Test
-          php: nightly
-          allow_failure: true
-          env: dependencies=lowest
-          before_install:
-              - composer remove --dev friendsofphp/php-cs-fixer # This is needed until PHP-CS-Fixer becames compatible with PHP 7.4
-        - php: nightly
-          allow_failure: true
-          env: dependencies=highest
-          before_install:
-              - composer remove --dev friendsofphp/php-cs-fixer # This is needed until PHP-CS-Fixer becames compatible with PHP 7.4
         - stage: Code coverage
-          php: 7.2
+          php: 7.3
           env: dependencies=highest
           script: vendor/bin/phpunit --verbose --coverage-clover=build/logs/clover.xml
           after_success:


### PR DESCRIPTION
Since PHP 7.3 has been released we can test it on Travis CI. I've also taken the moment to add [EditorConfig](https://editorconfig.org/) support to the project