### PR TITLE
Allow setting null on a custom field to unset it from a lead

### DIFF
--- a/src/LooplineSystems/CloseIoApiWrapper/Model/Lead.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Model/Lead.php
@@ -284,6 +284,22 @@ class Lead implements \JsonSerializable
     }
 
     /**
+     * Sets the value of a custom field. By passing a `null` value the field
+     * will be unset from the lead.
+     *
+     * @param string $name  The name or ID of the field
+     * @param mixed  $value The value
+     *
+     * @return $this
+     */
+    public function setCustomField(string $name, $value)
+    {
+        $this->custom[$name] = $value;
+
+        return $this;
+    }
+
+    /**
      * @return string
      */
     public function getDateCreated()
@@ -626,5 +642,16 @@ class Lead implements \JsonSerializable
         $this->updated_by_name = $updated_by_name;
 
         return $this;
+    }
+
+    public function __set(string $name, $value)
+    {
+        if (strpos($name, 'custom.') === 0) {
+            @trigger_error('Setting a custom field using the $object->$fieldName syntax is deprecated since version 0.8. Use the setCustomField() method instead.', E_USER_DEPRECATED);
+
+            $this->custom[substr($name, 7)] = $value;
+        } else {
+            $this->$name = $value;
+        }
     }
 }


### PR DESCRIPTION
Closes #95

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no

I don't know if this can be considered a new feature or a bug fix, the only certain thing is that it's a BC break :disappointed: The problem fixed with this PR is that it was not possible to unset a custom field from a lead. API supports passing `null` values to remove the association between a field and a lead, however the code was filtering out from the JSON request all values that would evaluate to `false` using `array_filter` and this prevented any attempt to unset a field to fail.