### PR TITLE
Fix serialization of datetime fields not using the correct format

### DIFF
--- a/src/LooplineSystems/CloseIoApiWrapper/Client.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Client.php
@@ -139,7 +139,15 @@ final class Client implements ClientInterface
         $requestBody = null;
 
         if (!empty($request->getBodyParams())) {
-            $requestBody = json_encode($request->getBodyParams());
+            $params = $request->getBodyParams();
+
+            foreach ($params as $name => $value) {
+                if ($value instanceof \DateTimeInterface) {
+                    $params[$name] = $value->format(DATE_ATOM);
+                }
+            }
+
+            $requestBody = json_encode($params);
         }
 
         $rawRequest = $this->messageFactory->createRequest($request->getMethod(), $request->getUrl(), [], $requestBody);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no

This PR fixes a bug probably introduced with one of the latest commits that was causing the incorrect serialization of the datetime fields.