### PR TITLE
Fix wrong error when response is empty

### DIFF
--- a/src/LooplineSystems/CloseIoApiWrapper/CloseIoResponse.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/CloseIoResponse.php
@@ -134,6 +134,12 @@ class CloseIoResponse
      */
     private function decodeBody(): void
     {
+        if (empty($this->body) || $this->body === null) {
+            $this->decodedBody = [];
+
+            return;
+        }
+
         $this->decodedBody = json_decode($this->body, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {

--- a/tests/LooplineSystems/CloseIoApiWrapper/CloseIoResponseTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/CloseIoResponseTest.php
@@ -35,7 +35,7 @@ class CloseIoResponseTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider getDecodedBodyDataProvider
      */
-    public function testGetDecodedBody(string $body, array $expectedDecodedBody): void
+    public function testGetDecodedBody(?string $body, array $expectedDecodedBody): void
     {
         $response = new CloseIoResponse(new CloseIoRequest('GET', '/foo/'), 200, $body);
 
@@ -47,6 +47,8 @@ class CloseIoResponseTest extends \PHPUnit\Framework\TestCase
         return [
             ['{"foo":"bar"}', ['foo' => 'bar']],
             ['false', []],
+            ['', []],
+            [null, []],
         ];
     }
 


### PR DESCRIPTION
Some API actions will return empty content (eg merge lead) that generate issue on response decoding. This behaviour is changed between php 5.6 and 7.x, so we need to fix id since the current release support 7.x development.

https://3v4l.org/1vZPv
https://3v4l.org/LFme1