### PR TITLE
Update dependencies to allow both HTTPlug 1.x and 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ php:
     - nightly
 
 env:
-    - dependencies=lowest
     - dependencies=highest
+    - dependencies=lowest
 
 matrix:
     fast_finish: true
@@ -29,8 +29,10 @@ jobs:
         - stage: Code style & static analysis
           name: PHP CS Fixer
           script: composer phpcs
-        - script: composer phpstan
-          name: PHPStan
+          env: dependencies=highest
+        - name: PHPStan
+          script: composer phpstan
+          env: dependencies=highest
         - stage: Code coverage
           php: 7.3
           env: dependencies=highest

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "loopline-systems/closeio-api-wrapper",
     "description": "A PHP wrapper for the Close.io Api",
     "license": "MIT",
-    "keywords": ["closeio php wrapper"],
+    "keywords": ["closeio", "close.io", "php", "api", "rest-api"],
     "authors": [
         {
             "name": "Michael Devery",
@@ -18,28 +18,23 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": "^7.1",
         "ext-json": "*",
-        "doctrine/inflector": "^1.3.0",
+        "doctrine/inflector": "^1.3",
         "fig/http-message-util": "^1.1",
-        "php-http/client-common": "^1.7",
+        "php-http/client-common": "^1.5|^2.0",
         "php-http/client-implementation": "^1.0",
-        "php-http/discovery": "^1.4",
-        "php-http/httplug": "^1.1",
+        "php-http/discovery": "^1.6",
+        "php-http/httplug": "^1.1|^2.0",
         "psr/http-message-implementation": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",
         "php-coveralls/php-coveralls": "^2.0",
-        "php-http/curl-client": "^1.7",
-        "php-http/message": "^1.7",
         "php-http/mock-client": "^1.1",
         "phpstan/phpstan": "^0.10.3",
-        "phpunit/phpunit": "^7.3.1",
-        "psr/http-message-implementation": "^1.0",
-        "symfony/options-resolver": "^3.0|^4.0",
-        "symfony/phpunit-bridge": "^4.1",
-        "webmozart/assert": "^1.3"
+        "phpunit/phpunit": "^7.3",
+        "symfony/phpunit-bridge": "^4.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/LooplineSystems/CloseIoApiWrapper/Client.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Client.php
@@ -25,8 +25,8 @@ use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Discovery\UriFactoryDiscovery;
 use Http\Message\Authentication\BasicAuth;
-use Http\Message\MessageFactory;
-use Http\Message\UriFactory;
+use Http\Message\RequestFactory as RequestFactoryInterface;
+use Http\Message\UriFactory as UriFactoryInterface;
 use LooplineSystems\CloseIoApiWrapper\Exception\CloseIoException;
 use LooplineSystems\CloseIoApiWrapper\Exception\CloseIoResponseException;
 
@@ -58,28 +58,28 @@ final class Client implements ClientInterface
     private $httpClient;
 
     /**
-     * @var UriFactory The URI factory
+     * @var UriFactoryInterface The URI factory
      */
     private $uriFactory;
 
     /**
-     * @var MessageFactory The factory of PSR-7 requests
+     * @var RequestFactoryInterface The factory of PSR-7 requests
      */
-    private $messageFactory;
+    private $requestFactory;
 
     /**
      * Constructor.
      *
-     * @param Configuration            $configuration  The configuration of the client
-     * @param HttpClientInterface|null $httpClient     The HTTP client
-     * @param UriFactory|null          $uriFactory     The URI factory
-     * @param MessageFactory|null      $messageFactory The factory of PSR-7 requests
+     * @param Configuration                $configuration  The configuration of the client
+     * @param HttpClientInterface|null     $httpClient     The HTTP client
+     * @param UriFactoryInterface|null     $uriFactory     The URI factory
+     * @param RequestFactoryInterface|null $requestFactory The factory of PSR-7 requests
      */
-    public function __construct(Configuration $configuration, ?HttpClientInterface $httpClient = null, ?UriFactory $uriFactory = null, ?MessageFactory $messageFactory = null)
+    public function __construct(Configuration $configuration, ?HttpClientInterface $httpClient = null, ?UriFactoryInterface $uriFactory = null, ?RequestFactoryInterface $requestFactory = null)
     {
         $this->configuration = $configuration;
         $this->uriFactory = $uriFactory ?: UriFactoryDiscovery::find();
-        $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
+        $this->requestFactory = $requestFactory ?: MessageFactoryDiscovery::find();
         $this->httpClient = $this->createHttpClientInstance($httpClient ?: HttpClientDiscovery::find());
     }
 
@@ -150,7 +150,7 @@ final class Client implements ClientInterface
             $requestBody = json_encode($params);
         }
 
-        $rawRequest = $this->messageFactory->createRequest($request->getMethod(), $request->getUrl(), [], $requestBody);
+        $rawRequest = $this->requestFactory->createRequest($request->getMethod(), $request->getUrl(), [], $requestBody);
 
         try {
             $rawResponse = $this->httpClient->sendRequest($rawRequest);

--- a/src/LooplineSystems/CloseIoApiWrapper/ClientInterface.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/ClientInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace LooplineSystems\CloseIoApiWrapper;
 
-use Http\Client\HttpClient;
+use Http\Client\HttpClient as HttpClientInterface;
 use LooplineSystems\CloseIoApiWrapper\Exception\CloseIoException;
 use LooplineSystems\CloseIoApiWrapper\Exception\CloseIoResponseException;
 use LooplineSystems\CloseIoApiWrapper\Exception\JsonException;
@@ -36,9 +36,9 @@ interface ClientInterface
     /**
      * Gets the HTTP client, configured to authenticate with the server.
      *
-     * @return HttpClient
+     * @return HttpClientInterface
      */
-    public function getHttpClient(): HttpClient;
+    public function getHttpClient(): HttpClientInterface;
 
     /**
      * Sends a GET request to Close.io REST API and returns the result.

--- a/src/LooplineSystems/CloseIoApiWrapper/CloseIoResponse.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/CloseIoResponse.php
@@ -33,7 +33,7 @@ class CloseIoResponse
     protected $httpStatusCode;
 
     /**
-     * @var null|string The body response
+     * @var string|null The body response
      */
     protected $body;
 
@@ -52,7 +52,7 @@ class CloseIoResponse
      *
      * @param CloseIoRequest $request        The original request that returned this response
      * @param int            $httpStatusCode The status code of this response
-     * @param null|string    $body           The body response
+     * @param string|null    $body           The body response
      * @param array          $headers        The returned HTTP headers
      *
      * @throws JsonException If the response body failed to be decoded as JSON
@@ -90,7 +90,7 @@ class CloseIoResponse
     /**
      * Gets the body content returned by this response.
      *
-     * @return null|string
+     * @return string|null
      */
     public function getBody(): ?string
     {


### PR DESCRIPTION
Simple PR to update the `composer.json` to remove some dependencies that should not be required by this library and others that were unused. I've also updated the dependencies to allow installing the newest version of HTTPlug. Unfortunately we cannot typehint against PSR-17/PSR-18 if we don't drop support for HTTPlug 1.x and I'm not sure we should because there are many other packages requiring such version, so it may be possible that someone using this library won't be able to install it if some other dependency it relies on doesn't allow HTTPlug 2