### PR TITLE
Refactor the exceptions and how they depends on each other

### DIFF
--- a/src/LooplineSystems/CloseIoApiWrapper/Exception/CloseIoAuthenticationException.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Exception/CloseIoAuthenticationException.php
@@ -19,6 +19,6 @@ namespace LooplineSystems\CloseIoApiWrapper\Exception;
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-class CloseIoAuthenticationException extends CloseIoException
+class CloseIoAuthenticationException extends CloseIoResponseException
 {
 }

--- a/src/LooplineSystems/CloseIoApiWrapper/Exception/CloseIoBadRequestException.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Exception/CloseIoBadRequestException.php
@@ -18,6 +18,6 @@ namespace LooplineSystems\CloseIoApiWrapper\Exception;
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-class CloseIoBadRequestException extends CloseIoException
+class CloseIoBadRequestException extends CloseIoResponseException
 {
 }

--- a/src/LooplineSystems/CloseIoApiWrapper/Exception/CloseIoResourceNotFoundException.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Exception/CloseIoResourceNotFoundException.php
@@ -18,6 +18,6 @@ namespace LooplineSystems\CloseIoApiWrapper\Exception;
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-class CloseIoResourceNotFoundException extends CloseIoException
+class CloseIoResourceNotFoundException extends CloseIoResponseException
 {
 }

--- a/src/LooplineSystems/CloseIoApiWrapper/Exception/CloseIoResponseException.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Exception/CloseIoResponseException.php
@@ -54,18 +54,15 @@ class CloseIoResponseException extends CloseIoException
      */
     public static function create(CloseIoResponse $response): self
     {
-        $data = $response->getDecodedBody();
-        $message = $data['error'] ?? self::UNKNOWN_ERROR_MESSAGE;
-
         switch ($response->getHttpStatusCode()) {
             case StatusCodeInterface::STATUS_UNAUTHORIZED:
-                return new static($response, new CloseIoAuthenticationException($message, 0));
+                return new CloseIoAuthenticationException($response);
             case StatusCodeInterface::STATUS_TOO_MANY_REQUESTS:
-                return new static($response, new CloseIoThrottleException($message, 0));
+                return new CloseIoThrottleException($response);
             case StatusCodeInterface::STATUS_NOT_FOUND:
-                return new static($response, new CloseIoResourceNotFoundException($message, 0));
+                return new CloseIoResourceNotFoundException($response);
             case StatusCodeInterface::STATUS_BAD_REQUEST:
-                return new static($response, new CloseIoBadRequestException($message, 0));
+                return new CloseIoBadRequestException($response);
             default:
                 return new static($response);
         }

--- a/src/LooplineSystems/CloseIoApiWrapper/Exception/CloseIoThrottleException.php
+++ b/src/LooplineSystems/CloseIoApiWrapper/Exception/CloseIoThrottleException.php
@@ -19,6 +19,6 @@ namespace LooplineSystems\CloseIoApiWrapper\Exception;
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-class CloseIoThrottleException extends CloseIoException
+class CloseIoThrottleException extends CloseIoResponseException
 {
 }

--- a/tests/LooplineSystems/CloseIoApiWrapper/Exception/CloseIoResponseExceptionTest.php
+++ b/tests/LooplineSystems/CloseIoApiWrapper/Exception/CloseIoResponseExceptionTest.php
@@ -48,17 +48,14 @@ class CloseIoResponseExceptionTest extends TestCase
     /**
      * @dataProvider createDataProvider
      */
-    public function testCreate(int $httpStatusCode, string $responseBody, string $expectedErrorMessage, ?string $expectedPreviousExceptionClass = null): void
+    public function testCreate(int $httpStatusCode, string $responseBody, string $expectedExceptionClass, string $expectedErrorMessage): void
     {
         $request = new CloseIoRequest(RequestMethodInterface::METHOD_GET, 'http://www.example.com');
         $response = new CloseIoResponse($request, $httpStatusCode, $responseBody);
         $exception = CloseIoResponseException::create($response);
 
+        $this->assertInstanceOf($expectedExceptionClass, $exception);
         $this->assertEquals($expectedErrorMessage, $exception->getMessage());
-
-        if (null !== $expectedPreviousExceptionClass) {
-            $this->assertInstanceOf($expectedPreviousExceptionClass, $exception->getPrevious());
-        }
     }
 
     public function createDataProvider(): array
@@ -67,30 +64,31 @@ class CloseIoResponseExceptionTest extends TestCase
             [
                 StatusCodeInterface::STATUS_UNAUTHORIZED,
                 '{"error":"foo"}',
-                'foo',
                 CloseIoAuthenticationException::class,
+                'foo',
             ],
             [
                 StatusCodeInterface::STATUS_TOO_MANY_REQUESTS,
                 '{"error":"foo"}',
-                'foo',
                 CloseIoThrottleException::class,
+                'foo',
             ],
             [
                 StatusCodeInterface::STATUS_NOT_FOUND,
                 '{"error":"foo"}',
-                'foo',
                 CloseIoResourceNotFoundException::class,
+                'foo',
             ],
             [
                 StatusCodeInterface::STATUS_BAD_REQUEST,
                 '{"error":"foo"}',
-                'foo',
                 CloseIoBadRequestException::class,
+                'foo',
             ],
             [
                 StatusCodeInterface::STATUS_SERVICE_UNAVAILABLE,
                 '{}',
+                CloseIoResponseException::class,
                 'Unknown error from Close.io REST API.',
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| License       | MIT

This PR refactorizes how the exceptions are created and how they depends on each other, switching from a model that always throw a generic exception that as previous exception stores the specific exception to a model where the specific exception is directly thrown, making it possible to effectively catch it