### PR TITLE
Test against PHP 7.4snapshot instead of nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
-    - nightly
+    - 7.4snapshot
 
 env:
     - dependencies=highest


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Since `nightly` corresponds to PHP 8 the build is now failing in Travis CI. With this change we are instead going to test against the next version which will be 7.4