### PR TITLE
Prevent the request body parameters to be put in the query string

### DIFF
--- a/src/Api/CallActivityApi.php
+++ b/src/Api/CallActivityApi.php
@@ -94,7 +94,7 @@ class CallActivityApi extends AbstractApi
      */
     public function create(CallActivity $activity): CallActivity
     {
-        $response = $this->client->post($this->prepareUrlForKey('add-call'), $activity->jsonSerialize());
+        $response = $this->client->post($this->prepareUrlForKey('add-call'), [], $activity->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new CallActivity($responseData);

--- a/src/Api/ContactApi.php
+++ b/src/Api/ContactApi.php
@@ -89,7 +89,7 @@ class ContactApi extends AbstractApi
      */
     public function create(Contact $contact): Contact
     {
-        $response = $this->client->post($this->prepareUrlForKey('add-contact'), $contact->jsonSerialize());
+        $response = $this->client->post($this->prepareUrlForKey('add-contact'), [], $contact->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new Contact($responseData);
@@ -108,7 +108,7 @@ class ContactApi extends AbstractApi
 
         $contact->setId(null);
 
-        $response = $this->client->put($this->prepareUrlForKey('update-contact', ['id' => $id]), $contact->jsonSerialize());
+        $response = $this->client->put($this->prepareUrlForKey('update-contact', ['id' => $id]), [], $contact->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new Contact($responseData);

--- a/src/Api/CustomFieldApi.php
+++ b/src/Api/CustomFieldApi.php
@@ -87,7 +87,7 @@ class CustomFieldApi extends AbstractApi
      */
     public function create(CustomField $customField): CustomField
     {
-        $response = $this->client->post($this->prepareUrlForKey('create-custom-field'), $customField->jsonSerialize());
+        $response = $this->client->post($this->prepareUrlForKey('create-custom-field'), [], $customField->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new CustomField($responseData);
@@ -106,7 +106,7 @@ class CustomFieldApi extends AbstractApi
 
         $customField->setId(null);
 
-        $response = $this->client->put($this->prepareUrlForKey('update-custom-field', ['id' => $id]), $customField->jsonSerialize());
+        $response = $this->client->put($this->prepareUrlForKey('update-custom-field', ['id' => $id]), [], $customField->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new CustomField($responseData);

--- a/src/Api/EmailActivityApi.php
+++ b/src/Api/EmailActivityApi.php
@@ -92,7 +92,7 @@ class EmailActivityApi extends AbstractApi
      */
     public function create(EmailActivity $activity): EmailActivity
     {
-        $response = $this->client->post($this->prepareUrlForKey('add-email'), $activity->jsonSerialize());
+        $response = $this->client->post($this->prepareUrlForKey('add-email'), [], $activity->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new EmailActivity($responseData);
@@ -111,7 +111,7 @@ class EmailActivityApi extends AbstractApi
 
         $activity->setId(null);
 
-        $response = $this->client->put($this->prepareUrlForKey('update-email', ['id' => $id]), $activity->jsonSerialize());
+        $response = $this->client->put($this->prepareUrlForKey('update-email', ['id' => $id]), [], $activity->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new EmailActivity($responseData);

--- a/src/Api/LeadApi.php
+++ b/src/Api/LeadApi.php
@@ -97,7 +97,7 @@ class LeadApi extends AbstractApi
     {
         $this->validateLeadForPost($lead);
 
-        $response = $this->client->post($this->prepareUrlForKey('add-lead'), $lead->jsonSerialize());
+        $response = $this->client->post($this->prepareUrlForKey('add-lead'), [], $lead->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new Lead($responseData);
@@ -116,7 +116,7 @@ class LeadApi extends AbstractApi
 
         $lead->setId(null);
 
-        $response = $this->client->put($this->prepareUrlForKey('update-lead', ['id' => $id]), $lead->jsonSerialize());
+        $response = $this->client->put($this->prepareUrlForKey('update-lead', ['id' => $id]), [], $lead->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new Lead($responseData);
@@ -150,7 +150,7 @@ class LeadApi extends AbstractApi
             throw new InvalidParamException('You need to specify two already existing leads in order to merge them');
         }
 
-        $this->client->post($this->prepareUrlForKey('merge-leads'), [
+        $this->client->post($this->prepareUrlForKey('merge-leads'), [], [
             'destination' => $destination->getId(),
             'source' => $source->getId(),
         ]);

--- a/src/Api/LeadStatusApi.php
+++ b/src/Api/LeadStatusApi.php
@@ -90,7 +90,7 @@ class LeadStatusApi extends AbstractApi
      */
     public function create(LeadStatus $leadStatus): LeadStatus
     {
-        $response = $this->client->post($this->prepareUrlForKey('add-status'), $leadStatus->jsonSerialize());
+        $response = $this->client->post($this->prepareUrlForKey('add-status'), [], $leadStatus->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new LeadStatus($responseData);
@@ -109,7 +109,7 @@ class LeadStatusApi extends AbstractApi
 
         $leadStatus->setId(null);
 
-        $response = $this->client->put($this->prepareUrlForKey('update-status', ['id' => $id]), $leadStatus->jsonSerialize());
+        $response = $this->client->put($this->prepareUrlForKey('update-status', ['id' => $id]), [], $leadStatus->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new LeadStatus($responseData);

--- a/src/Api/NoteActivityApi.php
+++ b/src/Api/NoteActivityApi.php
@@ -91,7 +91,7 @@ class NoteActivityApi extends AbstractApi
      */
     public function create(NoteActivity $activity): NoteActivity
     {
-        $response = $this->client->post($this->prepareUrlForKey('add-note'), $activity->jsonSerialize());
+        $response = $this->client->post($this->prepareUrlForKey('add-note'), [], $activity->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new NoteActivity($responseData);
@@ -110,7 +110,7 @@ class NoteActivityApi extends AbstractApi
 
         $activity->setId(null);
 
-        $response = $this->client->put($this->prepareUrlForKey('update-note', ['id' => $id]), $activity->jsonSerialize());
+        $response = $this->client->put($this->prepareUrlForKey('update-note', ['id' => $id]), [], $activity->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new NoteActivity($responseData);

--- a/src/Api/OpportunityApi.php
+++ b/src/Api/OpportunityApi.php
@@ -97,7 +97,7 @@ class OpportunityApi extends AbstractApi
      */
     public function create(Opportunity $opportunity): Opportunity
     {
-        $response = $this->client->post($this->prepareUrlForKey('add-opportunity'), $opportunity->jsonSerialize());
+        $response = $this->client->post($this->prepareUrlForKey('add-opportunity'), [], $opportunity->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new Opportunity($responseData);
@@ -116,7 +116,7 @@ class OpportunityApi extends AbstractApi
 
         $opportunity->setId(null);
 
-        $response = $this->client->put($this->prepareUrlForKey('update-opportunity', ['id' => $id]), $opportunity->jsonSerialize());
+        $response = $this->client->put($this->prepareUrlForKey('update-opportunity', ['id' => $id]), [], $opportunity->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new Opportunity($responseData);

--- a/src/Api/OpportunityStatusApi.php
+++ b/src/Api/OpportunityStatusApi.php
@@ -91,7 +91,7 @@ class OpportunityStatusApi extends AbstractApi
      */
     public function create(OpportunityStatus $opportunityStatus): OpportunityStatus
     {
-        $response = $this->client->post($this->prepareUrlForKey('add-status'), $opportunityStatus->jsonSerialize());
+        $response = $this->client->post($this->prepareUrlForKey('add-status'), [], $opportunityStatus->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new OpportunityStatus($responseData);
@@ -110,7 +110,7 @@ class OpportunityStatusApi extends AbstractApi
 
         $opportunityStatus->setId(null);
 
-        $response = $this->client->put($this->prepareUrlForKey('update-status', ['id' => $id]), $opportunityStatus->jsonSerialize());
+        $response = $this->client->put($this->prepareUrlForKey('update-status', ['id' => $id]), [], $opportunityStatus->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new OpportunityStatus($responseData);

--- a/src/Api/SmsActivityApi.php
+++ b/src/Api/SmsActivityApi.php
@@ -91,7 +91,7 @@ class SmsActivityApi extends AbstractApi
      */
     public function create(SmsActivity $activity): SmsActivity
     {
-        $response = $this->client->post($this->prepareUrlForKey('add-sms'), $activity->jsonSerialize());
+        $response = $this->client->post($this->prepareUrlForKey('add-sms'), [], $activity->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new SmsActivity($responseData);
@@ -110,7 +110,7 @@ class SmsActivityApi extends AbstractApi
 
         $activity->setId(null);
 
-        $response = $this->client->put($this->prepareUrlForKey('update-sms', ['id' => $id]), $activity->jsonSerialize());
+        $response = $this->client->put($this->prepareUrlForKey('update-sms', ['id' => $id]), [], $activity->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new SmsActivity($responseData);

--- a/src/Api/TaskApi.php
+++ b/src/Api/TaskApi.php
@@ -89,7 +89,7 @@ class TaskApi extends AbstractApi
      */
     public function create(Task $task): Task
     {
-        $response = $this->client->post($this->prepareUrlForKey('add-task'), $task->jsonSerialize());
+        $response = $this->client->post($this->prepareUrlForKey('add-task'), [], $task->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new Task($responseData);
@@ -108,7 +108,7 @@ class TaskApi extends AbstractApi
 
         $task->setId(null);
 
-        $response = $this->client->put($this->prepareUrlForKey('update-task', ['id' => $id]), $task->jsonSerialize());
+        $response = $this->client->put($this->prepareUrlForKey('update-task', ['id' => $id]), [], $task->jsonSerialize());
         $responseData = $response->getDecodedBody();
 
         return new Task($responseData);

--- a/src/Client.php
+++ b/src/Client.php
@@ -102,33 +102,33 @@ final class Client implements ClientInterface
     /**
      * {@inheritdoc}
      */
-    public function get(string $endpoint, array $params = []): CloseIoResponse
+    public function get(string $endpoint, array $queryParams = []): CloseIoResponse
     {
-        return $this->sendRequest(new CloseIoRequest(RequestMethodInterface::METHOD_GET, $endpoint, $params));
+        return $this->sendRequest(new CloseIoRequest(RequestMethodInterface::METHOD_GET, $endpoint, $queryParams));
     }
 
     /**
      * {@inheritdoc}
      */
-    public function post(string $endpoint, array $params = []): CloseIoResponse
+    public function post(string $endpoint, array $queryParams = [], array $bodyParams = []): CloseIoResponse
     {
-        return $this->sendRequest(new CloseIoRequest(RequestMethodInterface::METHOD_POST, $endpoint, $params));
+        return $this->sendRequest(new CloseIoRequest(RequestMethodInterface::METHOD_POST, $endpoint, $queryParams, $bodyParams));
     }
 
     /**
      * {@inheritdoc}
      */
-    public function put(string $endpoint, array $params = []): CloseIoResponse
+    public function put(string $endpoint, array $queryParams = [], array $bodyParams = []): CloseIoResponse
     {
-        return $this->sendRequest(new CloseIoRequest(RequestMethodInterface::METHOD_PUT, $endpoint, $params));
+        return $this->sendRequest(new CloseIoRequest(RequestMethodInterface::METHOD_PUT, $endpoint, $queryParams, $bodyParams));
     }
 
     /**
      * {@inheritdoc}
      */
-    public function delete(string $endpoint, array $params = []): CloseIoResponse
+    public function delete(string $endpoint, array $queryParams = []): CloseIoResponse
     {
-        return $this->sendRequest(new CloseIoRequest(RequestMethodInterface::METHOD_DELETE, $endpoint, $params));
+        return $this->sendRequest(new CloseIoRequest(RequestMethodInterface::METHOD_DELETE, $endpoint, $queryParams));
     }
 
     /**
@@ -138,7 +138,7 @@ final class Client implements ClientInterface
     {
         $requestBody = null;
 
-        if (!empty($request->getBodyParams())) {
+        if (!empty($request->getBodyParams()) && \in_array($request->getMethod(), [RequestMethodInterface::METHOD_POST, RequestMethodInterface::METHOD_PUT], true)) {
             $params = $request->getBodyParams();
 
             foreach ($params as $name => $value) {

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -43,8 +43,8 @@ interface ClientInterface
     /**
      * Sends a GET request to Close.io REST API and returns the result.
      *
-     * @param string $endpoint The REST endpoint for the request
-     * @param array  $params   The parameters to send with the request
+     * @param string $endpoint    The REST endpoint for the request
+     * @param array  $queryParams The parameters to send in the query string
      *
      * @return CloseIoResponse
      *
@@ -52,13 +52,14 @@ interface ClientInterface
      * @throws CloseIoResponseException If the response errored
      * @throws JsonException            If the response body could not be parsed as JSON
      */
-    public function get(string $endpoint, array $params = []): CloseIoResponse;
+    public function get(string $endpoint, array $queryParams = []): CloseIoResponse;
 
     /**
      * Sends a POST request to Close.io REST API and returns the result.
      *
-     * @param string $endpoint The REST endpoint for the request
-     * @param array  $params   The parameters to send with the request
+     * @param string $endpoint    The REST endpoint for the request
+     * @param array  $queryParams The parameters to send in the query string
+     * @param array  $bodyParams  The parameters to send as body of the request
      *
      * @return CloseIoResponse
      *
@@ -66,13 +67,14 @@ interface ClientInterface
      * @throws CloseIoResponseException If the response errored
      * @throws JsonException            If the response body could not be parsed as JSON
      */
-    public function post(string $endpoint, array $params = []): CloseIoResponse;
+    public function post(string $endpoint, array $queryParams = [], array $bodyParams = []): CloseIoResponse;
 
     /**
      * Sends a PUT request to Close.io REST API and returns the result.
      *
-     * @param string $endpoint The REST endpoint for the request
-     * @param array  $params   The parameters to send with the request
+     * @param string $endpoint    The REST endpoint for the request
+     * @param array  $queryParams The parameters to send in the query string
+     * @param array  $bodyParams  The parameters to send as body of the request
      *
      * @return CloseIoResponse
      *
@@ -80,13 +82,13 @@ interface ClientInterface
      * @throws CloseIoResponseException If the response errored
      * @throws JsonException            If the response body could not be parsed as JSON
      */
-    public function put(string $endpoint, array $params = []): CloseIoResponse;
+    public function put(string $endpoint, array $queryParams = [], array $bodyParams = []): CloseIoResponse;
 
     /**
      * Sends a DELETE request to Close.io REST API and returns the result.
      *
-     * @param string $endpoint The REST endpoint for the request
-     * @param array  $params   The parameters to send with the request
+     * @param string $endpoint    The REST endpoint for the request
+     * @param array  $queryParams The parameters to send in the query string
      *
      * @return CloseIoResponse
      *
@@ -94,7 +96,7 @@ interface ClientInterface
      * @throws CloseIoResponseException If the response errored
      * @throws JsonException            If the response body could not be parsed as JSON
      */
-    public function delete(string $endpoint, array $params = []): CloseIoResponse;
+    public function delete(string $endpoint, array $queryParams = []): CloseIoResponse;
 
     /**
      * Sends a request to the server and returns the response.

--- a/src/CloseIoRequest.php
+++ b/src/CloseIoRequest.php
@@ -34,20 +34,26 @@ class CloseIoRequest
     protected $endpoint;
 
     /**
-     * @var array The parameters to send with this request
+     * @var array The parameters to send in the query string
      */
-    protected $params = [];
+    protected $queryParams = [];
+
+    /**
+     * @var array The parameters to send in the body
+     */
+    protected $bodyParams = [];
 
     /**
      * Constructor.
      *
-     * @param string $method   The HTTP method
-     * @param string $endpoint The REST endpoint
-     * @param array  $params   The parameters to send
+     * @param string $method      The HTTP method
+     * @param string $endpoint    The REST endpoint
+     * @param array  $queryParams The parameters to send in the query string
+     * @param array  $bodyParams  The parameters to send in the body
      *
      * @throws InvalidHttpMethodException
      */
-    public function __construct(string $method, string $endpoint, array $params = [])
+    public function __construct(string $method, string $endpoint, array $queryParams = [], array $bodyParams = [])
     {
         if (!\in_array($method, [RequestMethodInterface::METHOD_GET, RequestMethodInterface::METHOD_POST, RequestMethodInterface::METHOD_PUT, RequestMethodInterface::METHOD_DELETE], true)) {
             throw new InvalidHttpMethodException();
@@ -55,7 +61,8 @@ class CloseIoRequest
 
         $this->method = $method;
         $this->endpoint = $endpoint;
-        $this->params = $params;
+        $this->queryParams = $queryParams;
+        $this->bodyParams = $bodyParams;
     }
 
     /**
@@ -79,23 +86,23 @@ class CloseIoRequest
     }
 
     /**
-     * Gets the parameters to send with this request.
+     * Gets the parameters to send in the query string.
      *
      * @return array
      */
-    public function getParams(): array
+    public function getQueryParams(): array
     {
-        return $this->params;
+        return $this->queryParams;
     }
 
     /**
-     * Sets the parameters to send with this request.
+     * Sets the parameters to send in the query string of this request.
      *
-     * @param array $params The parameters
+     * @param array $queryParams The parameters
      */
-    public function setParams(array $params): void
+    public function setQueryParams(array $queryParams): void
     {
-        $this->params = $params;
+        $this->queryParams = $queryParams;
     }
 
     /**
@@ -106,11 +113,17 @@ class CloseIoRequest
      */
     public function getBodyParams(): array
     {
-        if (\in_array($this->method, [RequestMethodInterface::METHOD_POST, RequestMethodInterface::METHOD_PUT], true)) {
-            return $this->params;
-        }
+        return $this->bodyParams;
+    }
 
-        return [];
+    /**
+     * Sets the parameters to send as body of this request.
+     *
+     * @param array $bodyParams The parameters
+     */
+    public function setBodyParams(array $bodyParams): void
+    {
+        $this->bodyParams = $bodyParams;
     }
 
     /**
@@ -120,13 +133,7 @@ class CloseIoRequest
      */
     public function getUrl(): string
     {
-        $url = $this->endpoint;
-
-        if (\in_array($this->method, [RequestMethodInterface::METHOD_GET, RequestMethodInterface::METHOD_POST, RequestMethodInterface::METHOD_PUT], true)) {
-            $url = $this->appendParamsToUrl($url, $this->params);
-        }
-
-        return $url;
+        return $this->appendParamsToUrl($this->endpoint, $this->queryParams);
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -64,26 +64,28 @@ class ClientTest extends TestCase
     {
         $this->httpClient->addResponse(MessageFactoryDiscovery::find()->createResponse(StatusCodeInterface::STATUS_OK, null, [], '{}'));
 
-        $this->client->post('/foo/', ['foo' => 'bar', 'bar' => 'foo']);
+        $this->client->post('/foo/', ['foo' => 'bar'], ['bar' => 'foo']);
 
         $lastRequest = $this->httpClient->getLastRequest();
 
         $this->assertInstanceOf(RequestInterface::class, $lastRequest);
-        $this->assertEquals('https://app.close.io/api/v1/foo/?foo=bar&bar=foo', (string) $lastRequest->getUri());
+        $this->assertEquals('https://app.close.io/api/v1/foo/?foo=bar', (string) $lastRequest->getUri());
         $this->assertEquals('POST', $lastRequest->getMethod());
+        $this->assertEquals('{"bar":"foo"}', (string) $lastRequest->getBody());
     }
 
     public function testPut(): void
     {
         $this->httpClient->addResponse(MessageFactoryDiscovery::find()->createResponse(StatusCodeInterface::STATUS_OK, null, [], '{}'));
 
-        $this->client->put('/foo/', ['foo' => 'bar', 'bar' => 'foo']);
+        $this->client->put('/foo/', ['foo' => 'bar'], ['bar' => 'foo']);
 
         $lastRequest = $this->httpClient->getLastRequest();
 
         $this->assertInstanceOf(RequestInterface::class, $lastRequest);
-        $this->assertEquals('https://app.close.io/api/v1/foo/?foo=bar&bar=foo', (string) $lastRequest->getUri());
+        $this->assertEquals('https://app.close.io/api/v1/foo/?foo=bar', (string) $lastRequest->getUri());
         $this->assertEquals('PUT', $lastRequest->getMethod());
+        $this->assertEquals('{"bar":"foo"}', (string) $lastRequest->getBody());
     }
 
     public function testDelete(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| License       | MIT

This PR splits the query parameters from the body parameters of a request fixing a bug that was copying in the query string all the parameters of a `POST`/`PUT`/`PATCH`/`DELETE` request. Since I've added a new parameter to the public API these changes are breaking, however since we're still in `0.x` Semver specs allow any kind of breaking change to happen even between minor versions