### PR TITLE
Change base url from app.close.io to api.close.com

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -38,7 +38,7 @@ final class Configuration
      *
      * @throws \InvalidArgumentException If any of the parameters is invalid
      */
-    public function __construct(string $apiKey, string $baseUrl = 'https://app.close.io/api/v1')
+    public function __construct(string $apiKey, string $baseUrl = 'https://api.close.com/api/v1')
     {
         if (empty($apiKey)) {
             throw new \InvalidArgumentException('The API key must not be an empty string.');

--- a/tests/Api/LeadsApiTest.php
+++ b/tests/Api/LeadsApiTest.php
@@ -145,7 +145,7 @@ class LeadsApiTest extends \PHPUnit\Framework\TestCase
         $lastRequest = $this->httpClient->getLastRequest();
 
         $this->assertInstanceOf(RequestInterface::class, $lastRequest);
-        $this->assertEquals('https://app.close.io/api/v1/lead/foo/', (string) $lastRequest->getUri());
+        $this->assertEquals('https://api.close.com/api/v1/lead/foo/', (string) $lastRequest->getUri());
         $this->assertEquals('DELETE', $lastRequest->getMethod());
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -56,7 +56,7 @@ class ClientTest extends TestCase
         $lastRequest = $this->httpClient->getLastRequest();
 
         $this->assertInstanceOf(RequestInterface::class, $lastRequest);
-        $this->assertEquals('https://app.close.io/api/v1/foo/?foo=bar&bar=foo', (string) $lastRequest->getUri());
+        $this->assertEquals('https://api.close.com/api/v1/foo/?foo=bar&bar=foo', (string) $lastRequest->getUri());
         $this->assertEquals('GET', $lastRequest->getMethod());
     }
 
@@ -69,7 +69,7 @@ class ClientTest extends TestCase
         $lastRequest = $this->httpClient->getLastRequest();
 
         $this->assertInstanceOf(RequestInterface::class, $lastRequest);
-        $this->assertEquals('https://app.close.io/api/v1/foo/?foo=bar', (string) $lastRequest->getUri());
+        $this->assertEquals('https://api.close.com/api/v1/foo/?foo=bar', (string) $lastRequest->getUri());
         $this->assertEquals('POST', $lastRequest->getMethod());
         $this->assertEquals('{"bar":"foo"}', (string) $lastRequest->getBody());
     }
@@ -83,7 +83,7 @@ class ClientTest extends TestCase
         $lastRequest = $this->httpClient->getLastRequest();
 
         $this->assertInstanceOf(RequestInterface::class, $lastRequest);
-        $this->assertEquals('https://app.close.io/api/v1/foo/?foo=bar', (string) $lastRequest->getUri());
+        $this->assertEquals('https://api.close.com/api/v1/foo/?foo=bar', (string) $lastRequest->getUri());
         $this->assertEquals('PUT', $lastRequest->getMethod());
         $this->assertEquals('{"bar":"foo"}', (string) $lastRequest->getBody());
     }
@@ -97,7 +97,7 @@ class ClientTest extends TestCase
         $lastRequest = $this->httpClient->getLastRequest();
 
         $this->assertInstanceOf(RequestInterface::class, $lastRequest);
-        $this->assertEquals('https://app.close.io/api/v1/foo/', (string) $lastRequest->getUri());
+        $this->assertEquals('https://api.close.com/api/v1/foo/', (string) $lastRequest->getUri());
         $this->assertEquals('DELETE', $lastRequest->getMethod());
     }
 
@@ -127,28 +127,28 @@ class ClientTest extends TestCase
                 RequestMethodInterface::METHOD_GET,
                 ['foo' => 'bar'],
                 ['bar' => 'foo'],
-                'https://app.close.io/api/v1/foo/?foo=bar',
+                'https://api.close.com/api/v1/foo/?foo=bar',
                 '',
             ],
             [
                 RequestMethodInterface::METHOD_POST,
                 ['foo' => 'bar'],
                 ['bar' => 'foo'],
-                'https://app.close.io/api/v1/foo/?foo=bar',
+                'https://api.close.com/api/v1/foo/?foo=bar',
                 '{"bar":"foo"}',
             ],
             [
                 RequestMethodInterface::METHOD_PUT,
                 ['foo' => 'bar'],
                 ['bar' => 'foo'],
-                'https://app.close.io/api/v1/foo/?foo=bar',
+                'https://api.close.com/api/v1/foo/?foo=bar',
                 '{"bar":"foo"}',
             ],
             [
                 RequestMethodInterface::METHOD_DELETE,
                 ['foo' => 'bar'],
                 ['bar' => 'foo'],
-                'https://app.close.io/api/v1/foo/?foo=bar',
+                'https://api.close.com/api/v1/foo/?foo=bar',
                 '',
             ],
         ];


### PR DESCRIPTION
Hey loopline :) Eric from Close here! As part of an ongoing domain migration, we've changed the base url of our API from `https://app.close.io/api/v1/` to `https://api.close.com/api/v1/`

app.close.io/api/v1/ will continue to be supported, but is now deprecated. 

This PR makes that switch for your wrapper :) 