### PR TITLE
implement smarter validation for non-ascii urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 build/
 /composer.lock
 /.php_cs.cache
+/.phpunit.result.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,6 +1,6 @@
 <?php
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR2' => true,
         '@Symfony' => true,

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,11 @@
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.6",
         "php-http/httplug": "^1.1|^2.0",
-        "psr/http-message-implementation": "^1.0"
+        "psr/http-message-implementation": "^1.0",
+        "symfony/polyfill-intl-idn": "^1.22",
+        "symfony/polyfill-php74": "^1.22",
+        "symfony/polyfill-php80": "^1.22",
+        "symfony/polyfill-php81": "^1.22"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",
@@ -42,7 +46,9 @@
         "symfony/polyfill-php55": "*",
         "symfony/polyfill-php56": "*",
         "symfony/polyfill-php70": "*",
-        "symfony/polyfill-php71": "*"
+        "symfony/polyfill-php71": "*",
+        "symfony/polyfill-php72": "*",
+        "symfony/polyfill-php73": "*"
     },
     "autoload": {
         "psr-4": {
@@ -59,7 +65,7 @@
             "vendor/bin/phpunit --verbose"
         ],
         "phpcs": [
-            "vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run"
+            "vendor/bin/php-cs-fixer fix --verbose --diff --dry-run"
         ],
         "phpstan": [
             "vendor/bin/phpstan analyse src tests --level=4"

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace LooplineSystems\CloseIoApiWrapper;
 
+use LooplineSystems\CloseIoApiWrapper\Library\UrlUtils;
+
 /**
  * This class stores the configuration of the Close.io client.
  *
@@ -44,7 +46,7 @@ final class Configuration
             throw new \InvalidArgumentException('The API key must not be an empty string.');
         }
 
-        if (!filter_var($baseUrl, FILTER_VALIDATE_URL)) {
+        if (!UrlUtils::validate($baseUrl)) {
             throw new \InvalidArgumentException('The $baseUrl argument must be an absolute URL.');
         }
 

--- a/src/Library/UrlUtils.php
+++ b/src/Library/UrlUtils.php
@@ -1,0 +1,26 @@
+<?php
+
+ declare(strict_types=1);
+
+ namespace LooplineSystems\CloseIoApiWrapper\Library;
+
+ final class UrlUtils
+ {
+     public static function validate(string $url): bool
+     {
+         $host = parse_url($url, PHP_URL_HOST) ?: "";
+
+         $encodedHost = idn_to_ascii($host, INTL_IDNA_VARIANT_UTS46);
+         if ($encodedHost === false) {
+             return false;
+         }
+
+         $url = str_replace($host, $encodedHost, $url);
+
+         $path = parse_url($url, PHP_URL_PATH) ?: "";
+         $encodedPath = array_map('urlencode', explode('/', $path));
+         $url = str_replace($path, implode('/', $encodedPath), $url);
+
+         return filter_var($url, FILTER_VALIDATE_URL) ? true : false;
+     }
+ }

--- a/src/Model/Lead.php
+++ b/src/Model/Lead.php
@@ -17,6 +17,7 @@ use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidParamException;
 use LooplineSystems\CloseIoApiWrapper\Library\Exception\InvalidUrlException;
 use LooplineSystems\CloseIoApiWrapper\Library\JsonSerializableHelperTrait;
 use LooplineSystems\CloseIoApiWrapper\Library\ObjectHydrateHelperTrait;
+use LooplineSystems\CloseIoApiWrapper\Library\UrlUtils;
 
 class Lead implements \JsonSerializable
 {
@@ -515,7 +516,7 @@ class Lead implements \JsonSerializable
     public function setUrl($url)
     {
         // validate url
-        if (filter_var($url, FILTER_VALIDATE_URL)) {
+        if (!UrlUtils::validate($url)) {
             $this->url = $url;
         } else {
             throw new InvalidUrlException('"' . $url . '" is not a valid URL');

--- a/tests/Library/UrlUtilsTest.php
+++ b/tests/Library/UrlUtilsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+ declare(strict_types=1);
+
+ namespace Tests\LooplineSystems\CloseIoApiWrapper\Library;
+
+ use LooplineSystems\CloseIoApiWrapper\Library\UrlUtils;
+ use PHPUnit\Framework\TestCase;
+
+ final class UrlUtilsTest extends TestCase
+ {
+     /**
+      * @dataProvider provideUrl
+      */
+     public function testValidate(bool $isValid, string $url): void
+     {
+         $this->assertSame($isValid, UrlUtils::validate($url));
+     }
+
+     public function provideUrl(): \Generator
+     {
+         yield [true, "https://www.example.com"];
+
+         yield [true, "https://www.example.com/foo/bar/baz"];
+
+         yield [true, "https://www.example.com/foo/bär/bäz"];
+
+         yield [true, "https://www.exämple.com"];
+
+         yield [true, "https://www.exämple.com/foo/bär/bäz"];
+
+         yield [true, "https://www.🚀.com"];
+     }
+ }


### PR DESCRIPTION
This PR allows for urls containing non-ascii char to pass the validation, as `filter_var` wasn't up to the task.